### PR TITLE
patch.sh: Fix git am error exit condition

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -82,7 +82,8 @@ for patchset in ${PATCHSET} ; do
 	mkdir -p ${EXPORTPATH}/$patchset
 	for patch in $(ls -1 ${PATCHPATH}/$patchset/*.patch | sort -n) ; do
 		$ECHO -n "$patch: "
-		git am -q $patch && echo applied || exit 1
+		git am -q $patch || exit 1
+		echo applied
 	done
 
 	NEWCOMMIT="$(git log --oneline --no-abbrev -1 | awk '{print $1}')"


### PR DESCRIPTION
The exit should be conditional on `git am` failing, not on the `echo`
failing.  If `echo` is failing, you've got bigger problems.

Signed-off-by: Andrew Bradford andrew@bradfordembedded.com
