### PR TITLE
Pinmux-helper

### DIFF
--- a/patches/not-capebus/0104-bone-capemgr-Fix-crash-when-trying-to-remove-non-exi.patch
+++ b/patches/not-capebus/0104-bone-capemgr-Fix-crash-when-trying-to-remove-non-exi.patch
@@ -1,0 +1,40 @@
+From c2c90749248209a20bbe9013632ee95d8d4387de Mon Sep 17 00:00:00 2001
+From: Pantelis Antoniou <panto@antoniou-consulting.com>
+Date: Wed, 27 Feb 2013 18:35:09 +0200
+Subject: [PATCH] bone-capemgr: Fix crash when trying to remove non-existant
+ slot
+
+Wrong test for not-found case lead to crash. Fix.
+
+Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
+---
+ drivers/misc/cape/beaglebone/capemgr.c |   11 ++++-------
+ 1 files changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
+index 2656e3a..9f8da94 100644
+--- a/drivers/misc/cape/beaglebone/capemgr.c
++++ b/drivers/misc/cape/beaglebone/capemgr.c
+@@ -990,15 +990,12 @@ static ssize_t slots_store(struct device *dev, struct device_attribute *attr,
+ 		mutex_lock(&info->slots_list_mutex);
+ 		list_for_each_entry(slot, &info->slot_list, node) {
+ 			if (slotno == slot->slotno)
+-				break;
+-		}
+-
+-		/* found? */
+-		if (slot == NULL) {
+-			mutex_unlock(&info->slots_list_mutex);
+-			return -ENODEV;
++				goto found;
+ 		}
+ 
++		mutex_unlock(&info->slots_list_mutex);
++		return -ENODEV;
++found:
+ 		ret = bone_capemgr_remove_slot(slot);
+ 		mutex_unlock(&info->slots_list_mutex);
+ 
+-- 
+1.7.8.6
+


### PR DESCRIPTION
Add a helper to configure the pinmux.

I've tested the ability to configure the pinmux and unload the slot (using 1st commit), but there is an additional bug-fix to handle unloading the wrong slot number that I haven't yet tested (2nd commit).

Just wanted to get this pull request in so you know that it is here. I'll come back with the testing status once the kernel is built and loaded onto my board.
