### PR TITLE
3.8: arm: rename am335x-bonelt.dts -> am335x-boneblack.dts

### DIFF
--- a/patches/PG2/0001-beaglebone-black-1ghz-hack.patch
+++ b/patches/PG2/0001-beaglebone-black-1ghz-hack.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] beaglebone black: 1ghz hack
 
 Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts | 16 ++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts | 16 ++++++++++++++++
  arch/arm/boot/dts/am33xx.dtsi       |  2 +-
  2 files changed, 17 insertions(+), 1 deletion(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index e88723c..fdcbb60 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -33,3 +33,19 @@
  	status = "okay";
  };

--- a/patches/audio/0001-arm-dts-add-am33xx-mcasp1-dt-node.patch
+++ b/patches/audio/0001-arm-dts-add-am33xx-mcasp1-dt-node.patch
@@ -8,14 +8,14 @@ and Board specific.
 
 Signed-off-by: Hebbar, Gururaja <gururaja.hebbar@ti.com>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts |   14 ++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   14 ++++++++++++++
  arch/arm/boot/dts/am33xx.dtsi       |    9 +++++++++
  2 files changed, 23 insertions(+), 0 deletions(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index 87257ac..a97ee36 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -30,3 +30,17 @@
  	ti,non-removable;
  	status = "okay";

--- a/patches/audio/0002-arm-dts-add-DT-pinmux-details-for-I2C1.patch
+++ b/patches/audio/0002-arm-dts-add-DT-pinmux-details-for-I2C1.patch
@@ -3,7 +3,7 @@ From: Joel A Fernandes <joelagnel@ti.com>
 Date: Thu, 25 Oct 2012 00:07:14 -0500
 Subject: [PATCH 2/9] arm/dts: add DT pinmux details for I2C1
 
-Add Pinmux details for I2C1 for am335x-bonelt
+Add Pinmux details for I2C1 for am335x-boneblack
 ---
  arch/arm/boot/dts/am335x-bone-common.dtsi |    8 ++++++++
  1 files changed, 8 insertions(+), 0 deletions(-)

--- a/patches/audio/0003-Setup-am335x-bonelt-audio-DT.patch
+++ b/patches/audio/0003-Setup-am335x-bonelt-audio-DT.patch
@@ -1,20 +1,20 @@
 From bb789027ae1bae1c9ac8f88b5f42ef49d4fcfa83 Mon Sep 17 00:00:00 2001
 From: Joel A Fernandes <joelagnel@ti.com>
 Date: Thu, 25 Oct 2012 00:16:18 -0500
-Subject: [PATCH 3/9] Setup am335x-bonelt audio DT
+Subject: [PATCH 3/9] Setup am335x-boneblack audio DT
 
 Needs mcasp0 node
 
 Signed-off-by: Hebbar, Gururaja <gururaja.hebbar@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts |   26 ++++++++++++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   26 ++++++++++++++++++++++++++
  1 files changed, 26 insertions(+), 0 deletions(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index a97ee36..eb46747 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -9,6 +9,32 @@
  
  /include/ "am335x-bone-common.dtsi"

--- a/patches/audio/0004-AM33XX-bonelt-dts-Add-i2c3-and-mcasp0-pin-mxing.patch
+++ b/patches/audio/0004-AM33XX-bonelt-dts-Add-i2c3-and-mcasp0-pin-mxing.patch
@@ -5,13 +5,13 @@ Subject: [PATCH 4/9] AM33XX: bonelt/dts: Add i2c3 and mcasp0 pin mxing
 
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts |   20 ++++++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   20 ++++++++++++++++++++
  1 files changed, 20 insertions(+), 0 deletions(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index eb46747..fdbaa75 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -10,6 +10,24 @@
  /include/ "am335x-bone-common.dtsi"
  

--- a/patches/audio/0005-Codec-sits-on-i2c3-bus-when-cape-is-connected-to-bea.patch
+++ b/patches/audio/0005-Codec-sits-on-i2c3-bus-when-cape-is-connected-to-bea.patch
@@ -9,19 +9,19 @@ This patch adds i2c3 node and codec slave address.
 
 Adapted from following patch by Gururaja Hebbar <gururaja.hebbar@ti.com>:
 
-    On am335x-bonelt, codec TLV320AIC3x sits on i2c1 bus.
+    On am335x-boneblack, codec TLV320AIC3x sits on i2c1 bus.
     This patch also add I2C1 node with I2C frequency and TLV320AIC3x Codec
     I2C slave address.
 
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts |   12 ++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   12 ++++++++++++
  1 files changed, 12 insertions(+), 0 deletions(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index fdbaa75..987291b 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -53,6 +53,18 @@
  	};
  };

--- a/patches/capebus/0005-beaglebone-create-a-shared-dtsi-for-beaglebone-based.patch
+++ b/patches/capebus/0005-beaglebone-create-a-shared-dtsi-for-beaglebone-based.patch
@@ -9,10 +9,10 @@ Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
  arch/arm/boot/dts/Makefile                |   3 +-
  arch/arm/boot/dts/am335x-bone-common.dtsi | 290 ++++++++++++++++++++++++++++++
  arch/arm/boot/dts/am335x-bone.dts         | 281 +----------------------------
- arch/arm/boot/dts/am335x-bonelt.dts       |  20 +++
+ arch/arm/boot/dts/am335x-boneblack.dts       |  20 +++
  4 files changed, 313 insertions(+), 281 deletions(-)
  create mode 100644 arch/arm/boot/dts/am335x-bone-common.dtsi
- create mode 100644 arch/arm/boot/dts/am335x-bonelt.dts
+ create mode 100644 arch/arm/boot/dts/am335x-boneblack.dts
 
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
 index 5ebb44f..5c0789d 100644
@@ -24,7 +24,7 @@ index 5ebb44f..5c0789d 100644
  	am335x-evmsk.dtb \
 -	am335x-bone.dtb
 +	am335x-bone.dtb \
-+	am335x-bonelt.dtb
++	am335x-boneblack.dtb
  dtb-$(CONFIG_ARCH_ORION5X) += orion5x-lacie-ethernet-disk-mini-v2.dtb
  dtb-$(CONFIG_ARCH_PRIMA2) += prima2-evb.dtb
  dtb-$(CONFIG_ARCH_U8500) += snowball.dtb \
@@ -613,11 +613,11 @@ index bf87ceb..9abc1f3 100644
 -	status = "okay";
 -};
 +/include/ "am335x-bone-common.dtsi"
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 new file mode 100644
 index 0000000..cdc3dd0
 --- /dev/null
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -0,0 +1,20 @@
 +/*
 + * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/

--- a/patches/capebus/0006-beaglebone-enable-emmc-for-bonelt.patch
+++ b/patches/capebus/0006-beaglebone-enable-emmc-for-bonelt.patch
@@ -6,7 +6,7 @@ Subject: [PATCH 6/7] beaglebone: enable emmc for bonelt
 Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
 ---
  arch/arm/boot/dts/am335x-bone-common.dtsi |  1 +
- arch/arm/boot/dts/am335x-bonelt.dts       | 15 +++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts       | 15 +++++++++++++++
  2 files changed, 16 insertions(+)
 
 diff --git a/arch/arm/boot/dts/am335x-bone-common.dtsi b/arch/arm/boot/dts/am335x-bone-common.dtsi
@@ -21,10 +21,10 @@ index 9a7be8a..8295b30 100644
  			};
  		};
  
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index cdc3dd0..6cb2a51 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -11,6 +11,21 @@
  
  /include/ "am335x-bone-common.dtsi"

--- a/patches/hdmi/0006-am335x-bonelt-dts-Add-DT-node-to-probe-NXP-driver.patch
+++ b/patches/hdmi/0006-am335x-bonelt-dts-Add-DT-node-to-probe-NXP-driver.patch
@@ -1,17 +1,17 @@
 From b4b7e4ae83639f5d7919485d42d501e63b5f5bc3 Mon Sep 17 00:00:00 2001
 From: Joel A Fernandes <joelagnel@ti.com>
 Date: Tue, 20 Nov 2012 14:18:08 -0600
-Subject: [PATCH 6/8] am335x-bonelt/dts: Add DT node to probe NXP driver
+Subject: [PATCH 6/8] am335x-boneblack/dts: Add DT node to probe NXP driver
 
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts |   17 +++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index 87257ac..44814b4 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -30,3 +30,20 @@
  	ti,non-removable;
  	status = "okay";

--- a/patches/not-capebus/0099-beaglebone-switch-eMMC-to-8bit-mode.patch
+++ b/patches/not-capebus/0099-beaglebone-switch-eMMC-to-8bit-mode.patch
@@ -5,14 +5,14 @@ Subject: [PATCH 099/103] beaglebone: switch eMMC to 8bit mode
 
 Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
 ---
- arch/arm/boot/dts/am335x-bonelt.dts   | 2 +-
+ arch/arm/boot/dts/am335x-boneblack.dts   | 2 +-
  firmware/capes/cape-bone-2g-emmc1.dts | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/arch/arm/boot/dts/am335x-bonelt.dts b/arch/arm/boot/dts/am335x-bonelt.dts
+diff --git a/arch/arm/boot/dts/am335x-boneblack.dts b/arch/arm/boot/dts/am335x-boneblack.dts
 index 6cb2a51..e88723c 100644
---- a/arch/arm/boot/dts/am335x-bonelt.dts
-+++ b/arch/arm/boot/dts/am335x-bonelt.dts
+--- a/arch/arm/boot/dts/am335x-boneblack.dts
++++ b/arch/arm/boot/dts/am335x-boneblack.dts
 @@ -28,7 +28,7 @@
  
  &mmc2 {

--- a/patches/not-capebus/0120-BBB-tester-Introduce-board-DTS.patch
+++ b/patches/not-capebus/0120-BBB-tester-Introduce-board-DTS.patch
@@ -21,8 +21,8 @@ index 5c0789d..bc833fe 100644
  	am335x-evm.dtb \
  	am335x-evmsk.dtb \
  	am335x-bone.dtb \
--	am335x-bonelt.dtb
-+	am335x-bonelt.dtb \
+-	am335x-boneblack.dtb
++	am335x-boneblack.dtb \
 +	am335x-tester.dtb
  dtb-$(CONFIG_ARCH_ORION5X) += orion5x-lacie-ethernet-disk-mini-v2.dtb
  dtb-$(CONFIG_ARCH_PRIMA2) += prima2-evb.dtb


### PR DESCRIPTION
Rename am335x-bonelt.dts to am335x-boneblack.dts to reflect the actual
board name. Change all references to the dts file to match the new name.
Requires matching change in the U-Boot am335x_evm.h config.

Signed-off-by: Matt Porter mporter@ti.com
