### PR TITLE
Add continuous sampling via /dev/iio to ADC

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -24,7 +24,7 @@ EXTERNAL_TREE="git://github.com/torvalds/linux.git"
 EXTERNAL_BRANCH="master"
 EXTERNAL_SHA="8bb495e3f02401ee6f76d1b1d77f3ac9f079e376"
 
-PATCHSET="mainline-fixes mainline-dtc-fixes  mainline-dtc-overlays mainline-of-fixes  mainline-pdev-fixes mainline-dma-devel mainline-mmc-fixes mainline-dts-fixes mainline-i2c-fixes  mainline-pinctrl-fixes mainline-capemgr"
+PATCHSET="mainline-fixes mainline-dtc-fixes  mainline-dtc-overlays mainline-of-fixes  mainline-pdev-fixes mainline-dma-devel mainline-mmc-fixes mainline-dts-fixes mainline-i2c-fixes  mainline-pinctrl-fixes mainline-capemgr adc"
 
 git_kernel_stable () {
 	git pull git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git master --tags || true

--- a/patches/adc/0001-Forwarding-changes-from-mfd-next.patch
+++ b/patches/adc/0001-Forwarding-changes-from-mfd-next.patch
@@ -1,7 +1,7 @@
-From 19ce6d26f52fa58de38ffd95b44b715aa7d7a397 Mon Sep 17 00:00:00 2001
+From c1f751dbb05040014c3108478787a2847dc65caf Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 4 Jul 2013 22:18:06 +0100
-Subject: [PATCH 01/19] Forwarding changes from mfd-next
+Subject: [PATCH 01/22] Forwarding changes from mfd-next
 
 This patch applies the changes which are present in mfd-next at the moment.
 Its taken directly from the tree as a whole from a merge.

--- a/patches/adc/0001-Forwarding-changes-from-mfd-next.patch
+++ b/patches/adc/0001-Forwarding-changes-from-mfd-next.patch
@@ -1,9 +1,10 @@
-From f09a19a463cf85ecb2b3edb34f5f73337bc0e95e Mon Sep 17 00:00:00 2001
+From 19ce6d26f52fa58de38ffd95b44b715aa7d7a397 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 4 Jul 2013 22:18:06 +0100
-Subject: [PATCH] Forwarding changes from mfd-next
+Subject: [PATCH 01/19] Forwarding changes from mfd-next
 
 This patch applies the changes which are present in mfd-next at the moment.
+Its taken directly from the tree as a whole from a merge.
 ---
  .../bindings/input/touchscreen/ti-tsc-adc.txt      |   44 +++
  arch/arm/boot/dts/am335x-evm.dts                   |   14 +

--- a/patches/adc/0002-MFD-ti_tscadc-disable-TSC-control.patch
+++ b/patches/adc/0002-MFD-ti_tscadc-disable-TSC-control.patch
@@ -1,7 +1,7 @@
-From dec55037c80e16d1abef2dd7c3ab3491a46c4481 Mon Sep 17 00:00:00 2001
+From 94cf54d5d18ca70e9b1253abaf2de077a1a9e10e Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 4 Jul 2013 23:14:24 +0100
-Subject: [PATCH] MFD: ti_tscadc: disable TSC control
+Subject: [PATCH 02/19] MFD: ti_tscadc: disable TSC control
 
 Register bits when TSC not in use
 
@@ -18,7 +18,7 @@ by TI. Original author is Patil, Rachna
  1 file changed, 11 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
-index b003a16..6b87f37 100644
+index b003a16..d72001c 100644
 --- a/drivers/mfd/ti_am335x_tscadc.c
 +++ b/drivers/mfd/ti_am335x_tscadc.c
 @@ -208,13 +208,14 @@ static	int ti_tscadc_probe(struct platform_device *pdev)

--- a/patches/adc/0002-MFD-ti_tscadc-disable-TSC-control.patch
+++ b/patches/adc/0002-MFD-ti_tscadc-disable-TSC-control.patch
@@ -1,7 +1,7 @@
-From 94cf54d5d18ca70e9b1253abaf2de077a1a9e10e Mon Sep 17 00:00:00 2001
+From 3dd5b27fd24176a437f792f8434b1974a381332c Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 4 Jul 2013 23:14:24 +0100
-Subject: [PATCH 02/19] MFD: ti_tscadc: disable TSC control
+Subject: [PATCH 02/22] MFD: ti_tscadc: disable TSC control
 
 Register bits when TSC not in use
 

--- a/patches/adc/0003-IIO-ADC-ti_adc-Fix-1st-sample-read.patch
+++ b/patches/adc/0003-IIO-ADC-ti_adc-Fix-1st-sample-read.patch
@@ -1,7 +1,7 @@
-From 49e9f6b8c441d12634574d92685f66ff2eae8936 Mon Sep 17 00:00:00 2001
+From 51ed5efaf24b75469d6ced23b69451e4147d2222 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 5 Jul 2013 00:32:35 +0100
-Subject: [PATCH 03/19] IIO: ADC: ti_adc: Fix 1st sample read
+Subject: [PATCH 03/22] IIO: ADC: ti_adc: Fix 1st sample read
 
 Previously we tried to read data form ADC even before ADC sequencer
 

--- a/patches/adc/0003-IIO-ADC-ti_adc-Fix-1st-sample-read.patch
+++ b/patches/adc/0003-IIO-ADC-ti_adc-Fix-1st-sample-read.patch
@@ -1,7 +1,7 @@
-From 01bf5561951e572054aea2e18816bf08aad0d571 Mon Sep 17 00:00:00 2001
+From 49e9f6b8c441d12634574d92685f66ff2eae8936 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 5 Jul 2013 00:32:35 +0100
-Subject: [PATCH] IIO: ADC: ti_adc: Fix 1st sample read
+Subject: [PATCH 03/19] IIO: ADC: ti_adc: Fix 1st sample read
 
 Previously we tried to read data form ADC even before ADC sequencer
 

--- a/patches/adc/0004-iio-ti_am335x_adc-Added-iio_voltageX_scale.patch
+++ b/patches/adc/0004-iio-ti_am335x_adc-Added-iio_voltageX_scale.patch
@@ -1,7 +1,7 @@
-From 9a3c278a742cf0791aa26f8aa682a00aeb02034e Mon Sep 17 00:00:00 2001
+From 3345c2496bf6e1f73c0a77c156a0ea764eb3d713 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 5 Jul 2013 01:08:47 +0100
-Subject: [PATCH 04/19] iio: ti_am335x_adc: Added iio_voltageX_scale
+Subject: [PATCH 04/22] iio: ti_am335x_adc: Added iio_voltageX_scale
 
 in_voltageX_scale is supposed to give scaled voltages. This was
 missing in the TI driver and has been added for BBB.

--- a/patches/adc/0004-iio-ti_am335x_adc-Added-iio_voltageX_scale.patch
+++ b/patches/adc/0004-iio-ti_am335x_adc-Added-iio_voltageX_scale.patch
@@ -1,7 +1,7 @@
-From 6dafc9130e9d3137e5ce3d7b5692b4da115ac2bb Mon Sep 17 00:00:00 2001
+From 9a3c278a742cf0791aa26f8aa682a00aeb02034e Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 5 Jul 2013 01:08:47 +0100
-Subject: [PATCH] iio: ti_am335x_adc: Added iio_voltageX_scale
+Subject: [PATCH 04/19] iio: ti_am335x_adc: Added iio_voltageX_scale
 
 in_voltageX_scale is supposed to give scaled voltages. This was
 missing in the TI driver and has been added for BBB.

--- a/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
+++ b/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
@@ -1,7 +1,7 @@
-From c5f2977c8bcc0a3c4c466af1984a23de35effe09 Mon Sep 17 00:00:00 2001
+From 3122340ff57f28de5c4ea12545a245f8b6a3a669 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 19:36:34 +0100
-Subject: [PATCH 05/19] input: ti_tsc: Enable shared IRQ for TSC
+Subject: [PATCH 05/22] input: ti_tsc: Enable shared IRQ for TSC
 
 Touchscreen and ADC share the same IRQ line from parent
 

--- a/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
+++ b/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
@@ -1,0 +1,66 @@
+From c5f2977c8bcc0a3c4c466af1984a23de35effe09 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 19:36:34 +0100
+Subject: [PATCH 05/19] input: ti_tsc: Enable shared IRQ for TSC
+
+Touchscreen and ADC share the same IRQ line from parent
+
+MFD core.
+
+Previously only Touchscreen was interrupt based.
+
+With continuous mode support added in ADC driver, now driver requires
+
+interrupt to process the ADC samples, so enable shared IRQ flag bit for
+
+touchscreen.
+
+Forward ported from Arago tree
+---
+ drivers/input/touchscreen/ti_am335x_tsc.c |   16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index 0e9f02a..cf56cae 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -260,8 +260,16 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	unsigned int fsm;
+ 
+ 	status = titsc_readl(ts_dev, REG_IRQSTATUS);
+-	if (status & IRQENB_FIFO0THRES) {
+-
++ 
++        /*
++         * ADC and touchscreen share the IRQ line.
++         * FIFO1 threshold interrupt is used by ADC,
++         * hence return from touchscreen IRQ handler if FIFO1
++         * threshold interrupt occurred.
++         */
++        if (status & IRQENB_FIFO1THRES)
++                return IRQ_NONE;
++        else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+ 
+ 		if (ts_dev->pen_down && z1 != 0 && z2 != 0) {
+@@ -315,7 +323,7 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	}
+ 
+ 	if (irqclr) {
+-		titsc_writel(ts_dev, REG_IRQSTATUS, irqclr);
++		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr) );
+ 		am335x_tsc_se_update(ts_dev->mfd_tscadc);
+ 		return IRQ_HANDLED;
+ 	}
+@@ -389,7 +397,7 @@ static int titsc_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	err = request_irq(ts_dev->irq, titsc_irq,
+-			  0, pdev->dev.driver->name, ts_dev);
++			  IRQF_SHARED, pdev->dev.driver->name, ts_dev);
+ 	if (err) {
+ 		dev_err(&pdev->dev, "failed to allocate irq.\n");
+ 		goto err_free_mem;
+-- 
+1.7.9.5
+

--- a/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
+++ b/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
@@ -1,0 +1,612 @@
+From 61c145ed95d664cf2cc72fd69f6e3978c1072fd4 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 21:45:58 +0100
+Subject: [PATCH 06/19] iio: input: am335x_adc: Add continuous mode to adc
+
+This is a rather large patch. Which adds a rather large feature.
+The ADC supports continuous sampling. This is added to the driver.
+The IRQs are changed in the TSC drivers as they are shared with
+the ADC IRQ lines.
+
+Forward ported from Arago tree based on 3.2
+---
+ drivers/iio/adc/ti_am335x_adc.c           |  386 ++++++++++++++++++++++++-----
+ drivers/input/touchscreen/ti_am335x_tsc.c |    9 +-
+ drivers/mfd/ti_am335x_tscadc.c            |   12 +-
+ include/linux/mfd/ti_am335x_tscadc.h      |   12 +
+ 4 files changed, 351 insertions(+), 68 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 8a63203..1f6e800 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -29,11 +29,25 @@
+ #include <linux/math64.h>
+ #include <linux/mfd/ti_am335x_tscadc.h>
+ 
++#include <linux/stat.h>
++
++#include <linux/sched.h>
++#include <linux/iio/buffer.h>
++#include <linux/iio/trigger_consumer.h>
++#include <linux/iio/kfifo_buf.h>
++#include <linux/iio/sysfs.h>
++#include <linux/delay.h>
++
+ struct tiadc_device {
+ 	struct ti_tscadc_dev *mfd_tscadc;
+ 	int channels;
+ 	u8 channel_line[8];
+ 	u8 channel_step[8];
++	struct work_struct      poll_work;
++	wait_queue_head_t       wq_data_avail;
++	int                     irq;
++	bool                    is_continuous_mode;
++        u16                     *buffer;
+ };
+ 
+ static unsigned int tiadc_readl(struct tiadc_device *adc, unsigned int reg)
+@@ -56,7 +70,7 @@ static u32 get_adc_step_mask(struct tiadc_device *adc_dev)
+ 	return step_en;
+ }
+ 
+-static void tiadc_step_config(struct tiadc_device *adc_dev)
++static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ {
+ 	unsigned int stepconfig;
+ 	int i, steps;
+@@ -72,7 +86,11 @@ static void tiadc_step_config(struct tiadc_device *adc_dev)
+ 	 */
+ 
+ 	steps = TOTAL_STEPS - adc_dev->channels;
+-	stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++	if (mode == 0)
++            stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++	else
++			stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
++			| STEPCONFIG_MODE_SWCNT;
+ 
+ 	for (i = 0; i < adc_dev->channels; i++) {
+ 		int chan;
+@@ -88,6 +106,226 @@ static void tiadc_step_config(struct tiadc_device *adc_dev)
+ 
+ }
+ 
++static ssize_t tiadc_show_mode(struct device *dev,
++                struct device_attribute *attr, char *buf)
++{
++        struct iio_dev *indio_dev = dev_get_drvdata(dev);
++        struct tiadc_device *adc_dev = iio_priv(indio_dev);
++        unsigned int tmp;
++
++        tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
++        tmp &= STEPCONFIG_MODE(1);
++
++        if (tmp == 0x00)
++                return sprintf(buf, "oneshot\n");
++        else if (tmp == 0x01)
++                return sprintf(buf, "continuous\n");
++        else
++                return sprintf(buf, "Operation mode unknown\n");
++}
++
++static ssize_t tiadc_set_mode(struct device *dev,
++                struct device_attribute *attr, const char *buf, size_t count)
++{
++        struct iio_dev *indio_dev = dev_get_drvdata(dev);
++        struct tiadc_device *adc_dev = iio_priv(indio_dev);
++        unsigned config;
++
++        config = tiadc_readl(adc_dev, REG_CTRL);
++        config &= ~(CNTRLREG_TSCSSENB);
++        tiadc_writel(adc_dev, REG_CTRL, config);
++
++	if (!strncmp(buf, "oneshot", 7))
++               adc_dev->is_continuous_mode = false;
++        else if (!strncmp(buf, "continuous", 10))
++                adc_dev->is_continuous_mode = true;
++        else {
++                dev_err(dev, "Operational mode unknown\n");
++                return -EINVAL;
++        }
++ 
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
++        config = tiadc_readl(adc_dev, REG_CTRL);
++        tiadc_writel(adc_dev, REG_CTRL,
++                        (config | CNTRLREG_TSCSSENB));
++        return count;
++}
++
++static IIO_DEVICE_ATTR(mode, S_IRUGO | S_IWUSR, tiadc_show_mode,
++                tiadc_set_mode, 0);
++
++static struct attribute *tiadc_attributes[] = {
++        &iio_dev_attr_mode.dev_attr.attr,
++        NULL,
++};
++
++static const struct attribute_group tiadc_attribute_group = {
++        .attrs = tiadc_attributes,
++};
++
++static irqreturn_t tiadc_irq(int irq, void *private)
++{
++        struct iio_dev *idev = private;
++        struct tiadc_device *adc_dev = iio_priv(idev);
++	unsigned int status, config;
++
++        status = tiadc_readl(adc_dev, REG_IRQSTATUS);
++        if (status & IRQENB_FIFO1THRES) {
++                tiadc_writel(adc_dev, REG_IRQCLR,
++                                IRQENB_FIFO1THRES);
++
++                if (iio_buffer_enabled(idev)) {
++                        if (!work_pending(&adc_dev->poll_work))
++                                schedule_work(&adc_dev->poll_work);
++                } else {
++                        wake_up_interruptible(&adc_dev->wq_data_avail);
++                }
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                (status | IRQENB_FIFO1THRES));
++                return IRQ_HANDLED;
++        } else if ((status &  IRQENB_FIFO1OVRRUN) ||
++                        (status &  IRQENB_FIFO1UNDRFLW)) {
++                config = tiadc_readl(adc_dev,  REG_CTRL);
++                config &= ~( CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev,  REG_CTRL, config);
++ 
++                if (status &  IRQENB_FIFO1UNDRFLW)
++                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                        (status |  IRQENB_FIFO1UNDRFLW));
++                else
++                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                                (status |  IRQENB_FIFO1OVRRUN));
++ 
++                tiadc_writel(adc_dev,  REG_CTRL,
++                        (config |  CNTRLREG_TSCSSENB));
++                return IRQ_HANDLED;        
++	} else {
++                return IRQ_NONE;
++        }
++}
++
++static void tiadc_poll_handler(struct work_struct *work_s)
++{
++        struct tiadc_device *adc_dev =
++                container_of(work_s, struct tiadc_device, poll_work);
++        struct iio_dev *idev = iio_priv_to_dev(adc_dev);
++        struct iio_buffer *buffer = idev->buffer;
++        unsigned int fifo1count, readx1, status;
++        int i;
++        u32 *iBuf;
++
++        fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++        iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
++        if (iBuf == NULL)
++                return;
++        /*
++         * Wait for ADC sequencer to settle down.
++         * There could be a scenario where in we
++         * try to read data from ADC before
++         * it is available.
++         */
++        udelay(500);
++
++        for (i = 0; i < fifo1count; i++) {
++                readx1 = tiadc_readl(adc_dev, REG_FIFO1);
++                readx1 &= FIFOREAD_DATA_MASK;
++                iBuf[i] = readx1;
++        }
++
++        buffer->access->store_to(buffer, (u8 *) iBuf);
++        status = tiadc_readl(adc_dev, REG_IRQENABLE);
++        tiadc_writel(adc_dev, REG_IRQENABLE,
++                        (status | IRQENB_FIFO1THRES));
++
++        kfree(iBuf);
++}
++
++static int tiadc_buffer_preenable(struct iio_dev *idev)
++{
++        struct iio_buffer *buffer = idev->buffer;
++
++        buffer->access->set_bytes_per_datum(buffer, 16);
++        return 0;
++}
++
++static int tiadc_buffer_postenable(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++        struct iio_buffer *buffer = idev->buffer;
++        unsigned int enb, status, fifo1count;
++        int stepnum, i;
++        u8 bit;
++
++        if (!adc_dev->is_continuous_mode) {
++                printk("Data cannot be read continuously in one shot mode\n");
++                return -EINVAL;
++        } else {
++                status = tiadc_readl(adc_dev, REG_IRQENABLE);
++                tiadc_writel(adc_dev, REG_IRQENABLE,
++                                (status | IRQENB_FIFO1THRES)|
++                                 IRQENB_FIFO1OVRRUN |
++                                 IRQENB_FIFO1UNDRFLW);
++
++                fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++                for (i = 0; i < fifo1count; i++)
++                        tiadc_readl(adc_dev, REG_FIFO1);
++
++                tiadc_writel(adc_dev, REG_SE, 0x00);
++                for_each_set_bit(bit, buffer->scan_mask,
++                                adc_dev->channels) {
++                        struct iio_chan_spec const *chan = idev->channels + bit;
++                        /*
++                         * There are a total of 16 steps available
++                         * that are shared between ADC and touchscreen.
++                         * We start configuring from step 16 to 0 incase of
++                         * ADC. Hence the relation between input channel
++                         * and step for ADC would be as below.
++                         */
++                        stepnum = chan->channel + 9;
++                        enb = tiadc_readl(adc_dev, REG_SE);
++                        enb |= (1 << stepnum);
++                        tiadc_writel(adc_dev, REG_SE, enb);
++                }
++                return 0;
++        }
++}
++
++static int tiadc_buffer_postdisable(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++  
++	tiadc_writel(adc_dev, REG_IRQCLR, (IRQENB_FIFO1THRES |
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW));
++        tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
++        return 0;
++}
++
++static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
++        .preenable = &tiadc_buffer_preenable,
++        .postenable = &tiadc_buffer_postenable,
++        .postdisable = &tiadc_buffer_postdisable,
++};
++
++static int tiadc_config_sw_ring(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++      //int ret;
++
++        idev->buffer = iio_kfifo_allocate(idev);
++        if (!idev->buffer)
++                return(-ENOMEM);
++
++ //     idev->buffer->access = &ring_sw_access_funcs;
++        idev->setup_ops = &tiadc_buffer_setup_ops;
++
++        INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
++
++        idev->modes |= INDIO_BUFFER_HARDWARE;
++        return 0;
++}
++
+ static const char * const chan_name_ain[] = {
+ 	"AIN0",
+ 	"AIN1",
+@@ -121,6 +359,7 @@ static int tiadc_channel_init(struct iio_dev *indio_dev, int channels)
+ 		chan->info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+ 						BIT(IIO_CHAN_INFO_SCALE);
+ 		chan->datasheet_name = chan_name_ain[chan->channel];
++		chan->scan_index = i;
+ 		chan->scan_type.sign = 'u';
+ 		chan->scan_type.realbits = 12;
+ 		chan->scan_type.storagebits = 32;
+@@ -148,68 +387,76 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 	u32 step_en;
+ 	unsigned long timeout = jiffies + usecs_to_jiffies
+ 				(IDLE_TIMEOUT * adc_dev->channels);
+-	step_en = get_adc_step_mask(adc_dev);
+-	am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
+- 
+-	/* Wait for ADC sequencer to complete sampling */
+-	while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
+-		if (time_after(jiffies, timeout))
+-			return -EAGAIN;
+-		}
+-	map_val = chan->channel + TOTAL_CHANNELS;
+ 
+-	/*
+-	 * When the sub-system is first enabled,
+-	 * the sequencer will always start with the
+-	 * lowest step (1) and continue until step (16).
+-	 * For ex: If we have enabled 4 ADC channels and
+-	 * currently use only 1 out of them, the
+-	 * sequencer still configures all the 4 steps,
+-	 * leading to 3 unwanted data.
+-	 * Hence we need to flush out this data.
+-	 */
+-
+-	for (i = 0; i < ARRAY_SIZE(adc_dev->channel_step); i++) {
+-		if (chan->channel == adc_dev->channel_line[i]) {
+-			step = adc_dev->channel_step[i];
+-			break;
++       if (adc_dev->is_continuous_mode) {
++               printk("One shot mode not enabled\n");
++               return -EINVAL;
++       } else {
++
++		step_en = get_adc_step_mask(adc_dev);
++		am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
++	 
++		/* Wait for ADC sequencer to complete sampling */
++		while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
++			if (time_after(jiffies, timeout))
++				return -EAGAIN;
++			}
++		map_val = chan->channel + TOTAL_CHANNELS;
++
++		/*
++		 * When the sub-system is first enabled,
++		 * the sequencer will always start with the
++		 * lowest step (1) and continue until step (16).
++		 * For ex: If we have enabled 4 ADC channels and
++		 * currently use only 1 out of them, the
++		 * sequencer still configures all the 4 steps,
++		 * leading to 3 unwanted data.
++		 * Hence we need to flush out this data.
++		 */
++
++		for (i = 0; i < ARRAY_SIZE(adc_dev->channel_step); i++) {
++			if (chan->channel == adc_dev->channel_line[i]) {
++				step = adc_dev->channel_step[i];
++				break;
++			}
+ 		}
+-	}
+-	if (WARN_ON_ONCE(step == UINT_MAX))
+-		return -EINVAL;
+-
+-	fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-	for (i = 0; i < fifo1count; i++) {
+-		read = tiadc_readl(adc_dev, REG_FIFO1);
+-		stepid = read & FIFOREAD_CHNLID_MASK;
+-		stepid = stepid >> 0x10;
+-
+-		if (stepid == map_val) {
+-			read = read & FIFOREAD_DATA_MASK;
+-			found = true;
+-			*val = read;
++		if (WARN_ON_ONCE(step == UINT_MAX))
++			return -EINVAL;
++
++		fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++		for (i = 0; i < fifo1count; i++) {
++			read = tiadc_readl(adc_dev, REG_FIFO1);
++			stepid = read & FIFOREAD_CHNLID_MASK;
++			stepid = stepid >> 0x10;
++
++			if (stepid == map_val) {
++				read = read & FIFOREAD_DATA_MASK;
++				found = true;
++				*val = read;
++			}
+ 		}
+-	}
+ 
+-	switch (mask){
+-		case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
+-					break;
+-		case IIO_CHAN_INFO_SCALE : {
+-			/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
+-			AVDD should come from DT.*/
+-			*val = div_u64( (u64)(*val) * 1800 , 4096);
+-			break;
++		switch (mask){
++			case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
++						break;
++			case IIO_CHAN_INFO_SCALE : {
++				/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
++				AVDD should come from DT.*/
++				*val = div_u64( (u64)(*val) * 1800 , 4096);
++				break;
++			}
++			default: break;
+ 		}
+-		default: break;
+-	}
+ 
+-	if (found == false)
+-		return -EBUSY;
+-	return IIO_VAL_INT;
++		if (found == false)
++			return -EBUSY;
++		return IIO_VAL_INT;
++	}
+ }
+ 
+ static const struct iio_info tiadc_info = {
+ 	.read_raw = &tiadc_read_raw,
++	.attrs = &tiadc_attribute_group,
+ };
+ 
+ static int tiadc_probe(struct platform_device *pdev)
+@@ -243,17 +490,37 @@ static int tiadc_probe(struct platform_device *pdev)
+ 		channels++;
+ 	}
+ 	adc_dev->channels = channels;
++	adc_dev->irq = adc_dev->mfd_tscadc->irq;
+ 
+ 	indio_dev->dev.parent = &pdev->dev;
+ 	indio_dev->name = dev_name(&pdev->dev);
+ 	indio_dev->modes = INDIO_DIRECT_MODE;
+ 	indio_dev->info = &tiadc_info;
+ 
+-	tiadc_step_config(adc_dev);
++	/* by default driver comes up with oneshot mode */
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
++	/* program FIFO threshold to value minus 1 */
++	tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+ 
+ 	err = tiadc_channel_init(indio_dev, adc_dev->channels);
+ 	if (err < 0)
+ 		goto err_free_device;
++    init_waitqueue_head(&adc_dev->wq_data_avail);
++
++    err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
++            indio_dev->name, indio_dev);
++    if (err)
++            goto err_free_irq;
++
++    err = tiadc_config_sw_ring(indio_dev);
++    if (err < 0)
++            goto err_unregister;
++ 
++    err = iio_buffer_register(indio_dev,
++                    indio_dev->channels, indio_dev->num_channels);
++    if (err < 0)
++            goto err_unregister;
+ 
+ 	err = iio_device_register(indio_dev);
+ 	if (err)
+@@ -263,6 +530,10 @@ static int tiadc_probe(struct platform_device *pdev)
+ 
+ 	return 0;
+ 
++err_unregister:
++
++err_free_irq:
++   free_irq(adc_dev->irq, indio_dev);
+ err_free_channels:
+ 	tiadc_channels_remove(indio_dev);
+ err_free_device:
+@@ -313,13 +584,14 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
++    tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
++    tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
+ 	/* Make sure ADC is powered up */
+ 	restore = tiadc_readl(adc_dev, REG_CTRL);
+ 	restore &= ~(CNTRLREG_POWERDOWN);
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+-	tiadc_step_config(adc_dev);
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index cf56cae..4bf2ee6 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -263,11 +263,14 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+  
+         /*
+          * ADC and touchscreen share the IRQ line.
+-         * FIFO1 threshold interrupt is used by ADC,
++         * FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
++         * interrupts are used by ADC,
+          * hence return from touchscreen IRQ handler if FIFO1
+-         * threshold interrupt occurred.
++         * related interrupts occurred.
+          */
+-        if (status & IRQENB_FIFO1THRES)
++       if ((status & IRQENB_FIFO1THRES) ||
++                       (status & IRQENB_FIFO1OVRRUN) ||
++                       (status & IRQENB_FIFO1UNDRFLW))
+                 return IRQ_NONE;
+         else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index d72001c..fdbd0d5 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -282,6 +282,8 @@ static int tscadc_suspend(struct device *dev)
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+ 
+ 	tscadc_writel(tscadc_dev, REG_SE, 0x00);
++        tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
++        tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
+ 	pm_runtime_put_sync(dev);
+ 
+ 	return 0;
+@@ -290,22 +292,16 @@ static int tscadc_suspend(struct device *dev)
+ static int tscadc_resume(struct device *dev)
+ {
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+-	unsigned int restore, ctrl;
+ 
+ 	pm_runtime_get_sync(dev);
+ 
+ 	/* context restore */
+-	ctrl = CNTRLREG_STEPCONFIGWRT |	CNTRLREG_STEPID;
+-	if (tscadc_dev->tsc_cell != -1)
+-		ctrl |= CNTRLREG_TSCENB | CNTRLREG_4WIRE;
+-	tscadc_writel(tscadc_dev, REG_CTRL, ctrl);
++	tscadc_writel(tscadc_dev, REG_IRQENABLE, tscadc_dev->irqstat);
+ 
+ 	if (tscadc_dev->tsc_cell != -1)
+ 		tscadc_idle_config(tscadc_dev);
+ 	am335x_tsc_se_update(tscadc_dev);
+-	restore = tscadc_readl(tscadc_dev, REG_CTRL);
+-	tscadc_writel(tscadc_dev, REG_CTRL,
+-			(restore | CNTRLREG_TSCSSENB));
++        tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
+ 
+ 	return 0;
+ }
+diff --git a/include/linux/mfd/ti_am335x_tscadc.h b/include/linux/mfd/ti_am335x_tscadc.h
+index db1791b..f436918 100644
+--- a/include/linux/mfd/ti_am335x_tscadc.h
++++ b/include/linux/mfd/ti_am335x_tscadc.h
+@@ -46,17 +46,23 @@
+ /* Step Enable */
+ #define STEPENB_MASK		(0x1FFFF << 0)
+ #define STEPENB(val)		((val) << 0)
++#define ENB(val)                        (1 << (val))
++#define STPENB_STEPENB          STEPENB(0x1FFFF)
++#define STPENB_STEPENB_TC       STEPENB(0x1FFF)
+ 
+ /* IRQ enable */
+ #define IRQENB_HW_PEN		BIT(0)
+ #define IRQENB_FIFO0THRES	BIT(2)
+ #define IRQENB_FIFO1THRES	BIT(5)
+ #define IRQENB_PENUP		BIT(9)
++#define IRQENB_FIFO1OVRRUN       BIT(6)
++#define IRQENB_FIFO1UNDRFLW      BIT(7)
+ 
+ /* Step Configuration */
+ #define STEPCONFIG_MODE_MASK	(3 << 0)
+ #define STEPCONFIG_MODE(val)	((val) << 0)
+ #define STEPCONFIG_MODE_HWSYNC	STEPCONFIG_MODE(2)
++#define STEPCONFIG_MODE_SWCNT   STEPCONFIG_MODE(1)
+ #define STEPCONFIG_AVG_MASK	(7 << 2)
+ #define STEPCONFIG_AVG(val)	((val) << 2)
+ #define STEPCONFIG_AVG_16	STEPCONFIG_AVG(4)
+@@ -124,6 +130,7 @@
+ #define	MAX_CLK_DIV		7
+ #define TOTAL_STEPS		16
+ #define TOTAL_CHANNELS		8
++#define FIFO1_THRESHOLD                        19
+ 
+ /*
+ * ADC runs at 3MHz, and it takes
+@@ -153,6 +160,11 @@ struct ti_tscadc_dev {
+ 
+ 	/* adc device */
+ 	struct adc_device *adc;
++
++    /* Context save */
++    unsigned int irqstat;
++    unsigned int ctrl;
++
+ };
+ 
+ static inline struct ti_tscadc_dev *ti_tscadc_dev_get(struct platform_device *p)
+-- 
+1.7.9.5
+

--- a/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
+++ b/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
@@ -1,7 +1,7 @@
-From 61c145ed95d664cf2cc72fd69f6e3978c1072fd4 Mon Sep 17 00:00:00 2001
+From b47a28f230cddeb717abb9f838e1d0f6bdddd497 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 21:45:58 +0100
-Subject: [PATCH 06/19] iio: input: am335x_adc: Add continuous mode to adc
+Subject: [PATCH 06/22] iio: input: am335x_adc: Add continuous mode to adc
 
 This is a rather large patch. Which adds a rather large feature.
 The ADC supports continuous sampling. This is added to the driver.

--- a/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
+++ b/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
@@ -1,0 +1,55 @@
+From 6c59285291fb843be5946cb556db60eaeae4e437 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 22:54:41 +0100
+Subject: [PATCH 07/19] MFD: ti_tscadc: ADC Clock check not required
+
+ADC is ideally expected to work at a frequency of 3MHz.
+
+The present code had a check, which returned error if the frequency
+
+went below the threshold  value. But since AM335x supports various
+
+working frequencies, this check is not required.
+
+Now the code just uses the internal ADC clock divider to set the ADC
+
+frequency w.r.t the sys clock.
+
+Signed-off-by: Patil, Rachna <rachna@ti.com>
+---
+ drivers/mfd/ti_am335x_tscadc.c       |    6 +-----
+ include/linux/mfd/ti_am335x_tscadc.h |    1 -
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index fdbd0d5..e7314e4 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -197,11 +197,7 @@ static	int ti_tscadc_probe(struct platform_device *pdev)
+ 	clock_rate = clk_get_rate(clk);
+ 	clk_put(clk);
+ 	clk_value = clock_rate / ADC_CLK;
+-	if (clk_value < MAX_CLK_DIV) {
+-		dev_err(&pdev->dev, "clock input less than min clock requirement\n");
+-		err = -EINVAL;
+-		goto err_disable_clk;
+-	}
++
+ 	/* TSCADC_CLKDIV needs to be configured to the value minus 1 */
+ 	clk_value = clk_value - 1;
+ 	tscadc_writel(tscadc, REG_CLKDIV, clk_value);
+diff --git a/include/linux/mfd/ti_am335x_tscadc.h b/include/linux/mfd/ti_am335x_tscadc.h
+index f436918..1516dc8 100644
+--- a/include/linux/mfd/ti_am335x_tscadc.h
++++ b/include/linux/mfd/ti_am335x_tscadc.h
+@@ -127,7 +127,6 @@
+ #define SEQ_STATUS BIT(5)
+ 
+ #define ADC_CLK			3000000
+-#define	MAX_CLK_DIV		7
+ #define TOTAL_STEPS		16
+ #define TOTAL_CHANNELS		8
+ #define FIFO1_THRESHOLD                        19
+-- 
+1.7.9.5
+

--- a/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
+++ b/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
@@ -1,7 +1,7 @@
-From 6c59285291fb843be5946cb556db60eaeae4e437 Mon Sep 17 00:00:00 2001
+From a87576da540cd7eb0f90fef47992ee3c3af07f02 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 22:54:41 +0100
-Subject: [PATCH 07/19] MFD: ti_tscadc: ADC Clock check not required
+Subject: [PATCH 07/22] MFD: ti_tscadc: ADC Clock check not required
 
 ADC is ideally expected to work at a frequency of 3MHz.
 

--- a/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
+++ b/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
@@ -1,7 +1,7 @@
-From 2b51f3742db91bab5e94bf5880a025272c5e284a Mon Sep 17 00:00:00 2001
+From b204a63037419bcf61d1bcf452db6fb3129f1702 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:03:09 +0100
-Subject: [PATCH 08/19] iio: TI-am335x-adc: Cleanup
+Subject: [PATCH 08/22] iio: TI-am335x-adc: Cleanup
 
 Cleaned up the code a bit. Some formatting.
 Some error handling paths corrected

--- a/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
+++ b/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
@@ -1,0 +1,89 @@
+From 2b51f3742db91bab5e94bf5880a025272c5e284a Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:03:09 +0100
+Subject: [PATCH 08/19] iio: TI-am335x-adc: Cleanup
+
+Cleaned up the code a bit. Some formatting.
+Some error handling paths corrected
+---
+ drivers/iio/adc/ti_am335x_adc.c |   33 +++++++++++++++++----------------
+ 1 file changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1f6e800..31665fa 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -311,13 +311,11 @@ static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
+ static int tiadc_config_sw_ring(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+-      //int ret;
+ 
+         idev->buffer = iio_kfifo_allocate(idev);
+         if (!idev->buffer)
+                 return(-ENOMEM);
+ 
+- //     idev->buffer->access = &ring_sw_access_funcs;
+         idev->setup_ops = &tiadc_buffer_setup_ops;
+ 
+         INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
+@@ -506,21 +504,22 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	err = tiadc_channel_init(indio_dev, adc_dev->channels);
+ 	if (err < 0)
+ 		goto err_free_device;
+-    init_waitqueue_head(&adc_dev->wq_data_avail);
+ 
+-    err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
+-            indio_dev->name, indio_dev);
+-    if (err)
+-            goto err_free_irq;
++	init_waitqueue_head(&adc_dev->wq_data_avail);
+ 
+-    err = tiadc_config_sw_ring(indio_dev);
+-    if (err < 0)
+-            goto err_unregister;
++	err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
++		indio_dev->name, indio_dev);
++	if (err)
++		goto err_free_irq;
++
++	err = tiadc_config_sw_ring(indio_dev);
++	if (err < 0)
++		goto err_unregister;
+  
+-    err = iio_buffer_register(indio_dev,
+-                    indio_dev->channels, indio_dev->num_channels);
+-    if (err < 0)
+-            goto err_unregister;
++	err = iio_buffer_register(indio_dev,
++		indio_dev->channels, indio_dev->num_channels);
++	if (err < 0)
++		goto err_unregister;
+ 
+ 	err = iio_device_register(indio_dev);
+ 	if (err)
+@@ -531,9 +530,9 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	return 0;
+ 
+ err_unregister:
+-
++	iio_buffer_unregister(indio_dev);
+ err_free_irq:
+-   free_irq(adc_dev->irq, indio_dev);
++	free_irq(adc_dev->irq, indio_dev);
+ err_free_channels:
+ 	tiadc_channels_remove(indio_dev);
+ err_free_device:
+@@ -548,7 +547,9 @@ static int tiadc_remove(struct platform_device *pdev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	u32 step_en;
+ 
++	free_irq(adc_dev->irq, indio_dev);
+ 	iio_device_unregister(indio_dev);
++	iio_buffer_unregister(indio_dev);
+ 	tiadc_channels_remove(indio_dev);
+ 
+ 	step_en = get_adc_step_mask(adc_dev);
+-- 
+1.7.9.5
+

--- a/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
+++ b/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
@@ -1,0 +1,82 @@
+From d9d8cd8ccf2137b21de96d18fa1183f7e26fa218 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:34:25 +0100
+Subject: [PATCH 09/19] IIO: ti_adc: Handle set to clear IRQENABLE register
+ properly.
+
+The driver is currently mishandling the IRQENABLE register. The driver
+
+should write a 1 for bits it wishes to set, and a zero for bits it does not
+
+wish to change. The read of the current register contents is not
+
+necessary.
+
+Write 0 = No action.
+
+Read 0 = Interrupt disabled (masked).
+
+Read 1 = Interrupt enabled.
+
+Write 1 = Enable interrupt.
+
+The current read/update/write method is currently not causing any
+
+problems, but could cause confusion in the future.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 31665fa..a86830b 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -211,7 +211,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+                 container_of(work_s, struct tiadc_device, poll_work);
+         struct iio_dev *idev = iio_priv_to_dev(adc_dev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int fifo1count, readx1, status;
++        unsigned int fifo1count, readx1;
+         int i;
+         u32 *iBuf;
+ 
+@@ -234,9 +234,8 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
+-        status = tiadc_readl(adc_dev, REG_IRQENABLE);
+-        tiadc_writel(adc_dev, REG_IRQENABLE,
+-                        (status | IRQENB_FIFO1THRES));
++        tiadc_writel(adc_dev, REG_IRQENABLE, 
++				IRQENB_FIFO1THRES);
+ 
+         kfree(iBuf);
+ }
+@@ -253,7 +252,7 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, status, fifo1count;
++        unsigned int enb, fifo1count;
+         int stepnum, i;
+         u8 bit;
+ 
+@@ -261,11 +260,10 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+                 printk("Data cannot be read continuously in one shot mode\n");
+                 return -EINVAL;
+         } else {
+-                status = tiadc_readl(adc_dev, REG_IRQENABLE);
+                 tiadc_writel(adc_dev, REG_IRQENABLE,
+-                                (status | IRQENB_FIFO1THRES)|
++                                (IRQENB_FIFO1THRES |
+                                  IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW);
++                                 IRQENB_FIFO1UNDRFLW));
+ 
+                 fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+                 for (i = 0; i < fifo1count; i++)
+-- 
+1.7.9.5
+

--- a/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
+++ b/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
@@ -1,7 +1,7 @@
-From d9d8cd8ccf2137b21de96d18fa1183f7e26fa218 Mon Sep 17 00:00:00 2001
+From bda047e53bee855b1849fc3726495fd573dbc71a Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:34:25 +0100
-Subject: [PATCH 09/19] IIO: ti_adc: Handle set to clear IRQENABLE register
+Subject: [PATCH 09/22] IIO: ti_adc: Handle set to clear IRQENABLE register
  properly.
 
 The driver is currently mishandling the IRQENABLE register. The driver

--- a/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
+++ b/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
@@ -1,7 +1,7 @@
-From 0fa2508c312750d76f48e29cbeef21fe3d44dec0 Mon Sep 17 00:00:00 2001
+From 06f887a51c82f83f6e4a24d2ff9e59db28d59b9d Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:42:38 +0100
-Subject: [PATCH 10/19] IIO: ti_adc: Handle set to clear IRQSTATUS register
+Subject: [PATCH 10/22] IIO: ti_adc: Handle set to clear IRQSTATUS register
  properly
 
 The driver is currently mishandling the IRQSTATUS register by peforming

--- a/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
+++ b/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
@@ -1,0 +1,61 @@
+From 0fa2508c312750d76f48e29cbeef21fe3d44dec0 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:42:38 +0100
+Subject: [PATCH 10/19] IIO: ti_adc: Handle set to clear IRQSTATUS register
+ properly
+
+The driver is currently mishandling the IRQSTATUS register by peforming
+
+a read/update/write cycle. The actual functionality of the register is as follows:
+
+Write 0 = No action.
+
+Read 0 = No (enabled) event pending.
+
+Read 1 = Event pending.
+
+Write 1 = Clear (raw) event.
+
+By reading the status and writing it back, the driver is clearing
+
+all pending events, not just the one indicated in the bitmask.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   13 +++++--------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index a86830b..5c95eba 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -182,7 +182,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                         wake_up_interruptible(&adc_dev->wq_data_avail);
+                 }
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                (status | IRQENB_FIFO1THRES));
++					IRQENB_FIFO1THRES);
+                 return IRQ_HANDLED;
+         } else if ((status &  IRQENB_FIFO1OVRRUN) ||
+                         (status &  IRQENB_FIFO1UNDRFLW)) {
+@@ -190,13 +190,10 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 config &= ~( CNTRLREG_TSCSSENB);
+                 tiadc_writel(adc_dev,  REG_CTRL, config);
+  
+-                if (status &  IRQENB_FIFO1UNDRFLW)
+-                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                        (status |  IRQENB_FIFO1UNDRFLW));
+-                else
+-                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                                (status |  IRQENB_FIFO1OVRRUN));
+- 
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW);
++
+                 tiadc_writel(adc_dev,  REG_CTRL,
+                         (config |  CNTRLREG_TSCSSENB));
+                 return IRQ_HANDLED;        
+-- 
+1.7.9.5
+

--- a/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
+++ b/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
@@ -1,7 +1,7 @@
-From 8e739fc130a230e54055d62b74df777ac938cffa Mon Sep 17 00:00:00 2001
+From 0da0bb41a0b72899c5d52f758063cf9a68a5703d Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:46:59 +0100
-Subject: [PATCH 11/19] IIO: ti_adc: Handle overrun before threshold event
+Subject: [PATCH 11/22] IIO: ti_adc: Handle overrun before threshold event
 
 If an overrun occurs, the threshold event is meaningless, handle
 

--- a/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
+++ b/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
@@ -1,0 +1,64 @@
+From 8e739fc130a230e54055d62b74df777ac938cffa Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:46:59 +0100
+Subject: [PATCH 11/19] IIO: ti_adc: Handle overrun before threshold event
+
+If an overrun occurs, the threshold event is meaningless, handle
+
+the overrun event first.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   29 ++++++++++++++---------------
+ 1 file changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 5c95eba..e510da7 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -171,7 +171,19 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+ 	unsigned int status, config;
+ 
+         status = tiadc_readl(adc_dev, REG_IRQSTATUS);
+-        if (status & IRQENB_FIFO1THRES) {
++        if (status & IRQENB_FIFO1OVRRUN) {
++                config = tiadc_readl(adc_dev, REG_CTRL);
++                config &= ~(CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev, REG_CTRL, config);
++
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW);
++ 
++                tiadc_writel(adc_dev, REG_CTRL,
++                       (config | CNTRLREG_TSCSSENB));
++		return IRQ_HANDLED;
++        } else if (status & IRQENB_FIFO1THRES) {
+                 tiadc_writel(adc_dev, REG_IRQCLR,
+                                 IRQENB_FIFO1THRES);
+ 
+@@ -183,20 +195,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 }
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 					IRQENB_FIFO1THRES);
+-                return IRQ_HANDLED;
+-        } else if ((status &  IRQENB_FIFO1OVRRUN) ||
+-                        (status &  IRQENB_FIFO1UNDRFLW)) {
+-                config = tiadc_readl(adc_dev,  REG_CTRL);
+-                config &= ~( CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev,  REG_CTRL, config);
+- 
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW);
+-
+-                tiadc_writel(adc_dev,  REG_CTRL,
+-                        (config |  CNTRLREG_TSCSSENB));
+-                return IRQ_HANDLED;        
++                return IRQ_HANDLED;      
+ 	} else {
+                 return IRQ_NONE;
+         }
+-- 
+1.7.9.5
+

--- a/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
+++ b/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
@@ -1,0 +1,60 @@
+From 67424c16077483f27e39f32df055361de9210d41 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:49:48 +0100
+Subject: [PATCH 12/19] iio: ti_adc: Avoid double threshold event
+
+The threshold event handler is being called before the FIFO has
+
+actually reached the threshold.
+
+The current code receives a FIFO threshold event, masks the interrupt,
+
+clears the event, and schedules a workqueue. The workqueue is run, it
+
+empties the FIFO, and unmasks the interrupt.
+
+In the above sequence, after the event is cleared, it immediately
+
+retriggers since the FIFO remains beyond the threshold. When the IRQ is
+
+unmasked, this triggered event generates another IRQ. However, as the
+
+FIFO has just been emptied, it is likely to not contain enough samples.
+
+The waits to clear the event until the FIFO has actually been emptied,
+
+in the workqueue. The unmasking and masking of the interrupt remains
+
+unchanged.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index e510da7..fcd414d 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -193,8 +193,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 } else {
+                         wake_up_interruptible(&adc_dev->wq_data_avail);
+                 }
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-					IRQENB_FIFO1THRES);
++
+                 return IRQ_HANDLED;      
+ 	} else {
+                 return IRQ_NONE;
+@@ -230,6 +229,8 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
++	tiadc_writel(adc_dev, REG_IRQSTATUS,
++				IRQENB_FIFO1THRES);
+         tiadc_writel(adc_dev, REG_IRQENABLE, 
+ 				IRQENB_FIFO1THRES);
+ 
+-- 
+1.7.9.5
+

--- a/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
+++ b/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
@@ -1,7 +1,7 @@
-From 67424c16077483f27e39f32df055361de9210d41 Mon Sep 17 00:00:00 2001
+From b0f24b422e9d2946d6d20e1f23fde8e42529cd55 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:49:48 +0100
-Subject: [PATCH 12/19] iio: ti_adc: Avoid double threshold event
+Subject: [PATCH 12/22] iio: ti_adc: Avoid double threshold event
 
 The threshold event handler is being called before the FIFO has
 

--- a/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
+++ b/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
@@ -1,7 +1,7 @@
-From ed79dfe1302bfed9443573b4b21de63307285b98 Mon Sep 17 00:00:00 2001
+From 48fc0286ef2b26dba6aa6c1d0ddf375702ab162c Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Thu, 11 Jul 2013 23:53:46 +0100
-Subject: [PATCH 13/19] IIO: ti_adc: Also clear threshold event when clearing
+Subject: [PATCH 13/22] IIO: ti_adc: Also clear threshold event when clearing
  overrun event
 
 When an overrun occurs, the FIFO is cleared. If a FIFO threshold event

--- a/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
+++ b/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
@@ -1,0 +1,34 @@
+From ed79dfe1302bfed9443573b4b21de63307285b98 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:53:46 +0100
+Subject: [PATCH 13/19] IIO: ti_adc: Also clear threshold event when clearing
+ overrun event
+
+When an overrun occurs, the FIFO is cleared. If a FIFO threshold event
+
+was pending, the data is now gone. Clear the threshold event when
+
+handling an overrun (or underflow).
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index fcd414d..1e48799 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -178,7 +178,8 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+ 
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+                                 IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW);
++                                IRQENB_FIFO1UNDRFLW |
++                                IRQENB_FIFO1THRES);
+  
+                 tiadc_writel(adc_dev, REG_CTRL,
+                        (config | CNTRLREG_TSCSSENB));
+-- 
+1.7.9.5
+

--- a/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
+++ b/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
@@ -1,7 +1,7 @@
-From f4aae1c13b5556a476d2eb793d7e06a874961014 Mon Sep 17 00:00:00 2001
+From cbb646469711967af0b4443741e0dd28d549c643 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 00:01:41 +0100
-Subject: [PATCH 14/19] IO: ti_adc: Reset and clear overrun status before
+Subject: [PATCH 14/22] IO: ti_adc: Reset and clear overrun status before
  capture.
 
 While not pulling out samples, the FIFO will fill up causing an

--- a/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
+++ b/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
@@ -1,0 +1,62 @@
+From f4aae1c13b5556a476d2eb793d7e06a874961014 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 00:01:41 +0100
+Subject: [PATCH 14/19] IO: ti_adc: Reset and clear overrun status before
+ capture.
+
+While not pulling out samples, the FIFO will fill up causing an
+
+overrun event. Before starting up another continuous sample, clear that
+
+event.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   24 +++++++++++++++---------
+ 1 file changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1e48799..eb47385 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -250,22 +250,28 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, fifo1count;
+-        int stepnum, i;
++        unsigned int enb, config;
++        int stepnum;
+         u8 bit;
+ 
+         if (!adc_dev->is_continuous_mode) {
+                 printk("Data cannot be read continuously in one shot mode\n");
+                 return -EINVAL;
+         } else {
+-                tiadc_writel(adc_dev, REG_IRQENABLE,
+-                                (IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW));
+ 
+-                fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-                for (i = 0; i < fifo1count; i++)
+-                        tiadc_readl(adc_dev, REG_FIFO1);
++                config = tiadc_readl(adc_dev, REG_CTRL);
++                tiadc_writel(adc_dev, REG_CTRL,
++                                        config & ~CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev, REG_CTRL,
++                                        config |  CNTRLREG_TSCSSENB);
++
++                tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                                 IRQENB_FIFO1THRES |
++                                 IRQENB_FIFO1OVRRUN |
++                                 IRQENB_FIFO1UNDRFLW);
++                tiadc_writel(adc_dev,  REG_IRQENABLE,
++                                 IRQENB_FIFO1THRES |
++                                 IRQENB_FIFO1OVRRUN);
+ 
+                 tiadc_writel(adc_dev, REG_SE, 0x00);
+                 for_each_set_bit(bit, buffer->scan_mask,
+-- 
+1.7.9.5
+

--- a/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
+++ b/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
@@ -1,7 +1,7 @@
-From da445afcc931b1114e740d8bf58ab4569c7090e9 Mon Sep 17 00:00:00 2001
+From a4dea7423ba82a89b6d931d2b4735233f02d0565 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 23:02:43 +0100
-Subject: [PATCH 15/19] IIO: ti_adc: Properly handle out of memory situation.
+Subject: [PATCH 15/22] IIO: ti_adc: Properly handle out of memory situation.
 
 If we fail to allocate a buffer, unmask the interrupt to allow a retry.
 

--- a/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
+++ b/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
@@ -1,0 +1,55 @@
+From da445afcc931b1114e740d8bf58ab4569c7090e9 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:02:43 +0100
+Subject: [PATCH 15/19] IIO: ti_adc: Properly handle out of memory situation.
+
+If we fail to allocate a buffer, unmask the interrupt to allow a retry.
+
+The interrupt handler will be re-run, and our workqueue rescheduled.
+
+If we are able to allocate memory next time around, everything will
+
+continue as normal, otherwise, we will eventually get an underrun.
+
+Before this patch, the driver would stop capturing without any
+
+indication of error to the IIO subsystem or the user.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index eb47385..69abde0 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -214,7 +214,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+         iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+-                return;
++                goto out;
+         /*
+          * Wait for ADC sequencer to settle down.
+          * There could be a scenario where in we
+@@ -230,12 +230,14 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
++	kfree(iBuf);
++
++out:	
+ 	tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 				IRQENB_FIFO1THRES);
+         tiadc_writel(adc_dev, REG_IRQENABLE, 
+ 				IRQENB_FIFO1THRES);
+-
+-        kfree(iBuf);
++    
+ }
+ 
+ static int tiadc_buffer_preenable(struct iio_dev *idev)
+-- 
+1.7.9.5
+

--- a/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
+++ b/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
@@ -1,7 +1,7 @@
-From cd5f86c841c75dec62e7f0a4d53e9a822cb83ff0 Mon Sep 17 00:00:00 2001
+From b3aba5bce5c90aab9929931ae24cf281685e923e Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 23:05:22 +0100
-Subject: [PATCH 16/19] IIO: ti_adc: Print error and handle short FIFO events
+Subject: [PATCH 16/22] IIO: ti_adc: Print error and handle short FIFO events
 
 In the case that the FIFO threshold handler gets called when the
 

--- a/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
+++ b/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
@@ -1,0 +1,43 @@
+From cd5f86c841c75dec62e7f0a4d53e9a822cb83ff0 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:05:22 +0100
+Subject: [PATCH 16/19] IIO: ti_adc: Print error and handle short FIFO events
+
+In the case that the FIFO threshold handler gets called when the
+
+FIFO has not actually reached the threshold, the driver will pass
+
+uninitialized memory to the IIO subsystem.
+
+In the past, this would occur due to bugs in the driver, those bugs
+
+have been fixed. However, it is still a good idea to close this just
+
+in case additional bugs in hardware or software exist.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 69abde0..c257169 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -212,6 +212,13 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         u32 *iBuf;
+ 
+         fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++        if (fifo1count * sizeof(u32) <
++                                buffer->access->get_bytes_per_datum(buffer)) {
++                dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
++                                                                __func__);
++                goto out;
++        }
++
+         iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+-- 
+1.7.9.5
+

--- a/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
+++ b/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
@@ -1,7 +1,7 @@
-From 17aef4d4ced67c488cd719ba3277e4815f04ee2e Mon Sep 17 00:00:00 2001
+From f2535b020f654f473e3814fe8326210aa78da22d Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 23:07:31 +0100
-Subject: [PATCH 17/19] IIO: ti_adc: Fix allocation count of FIFO buffer.
+Subject: [PATCH 17/22] IIO: ti_adc: Fix allocation count of FIFO buffer.
 
 Allocating an extra byte is not necessary here. The driver will check
 

--- a/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
+++ b/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
@@ -1,0 +1,30 @@
+From 17aef4d4ced67c488cd719ba3277e4815f04ee2e Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:07:31 +0100
+Subject: [PATCH 17/19] IIO: ti_adc: Fix allocation count of FIFO buffer.
+
+Allocating an extra byte is not necessary here. The driver will check
+
+that the allocation is large enough to satisfy the IIO subsystem.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index c257169..21294f2 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -219,7 +219,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+                 goto out;
+         }
+ 
+-        iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
++        iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+         /*
+-- 
+1.7.9.5
+

--- a/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
+++ b/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
@@ -1,7 +1,7 @@
-From 80ad5301e3816b406bed0d0fa6c20c83b1895567 Mon Sep 17 00:00:00 2001
+From 1871b4433db25af99c95342f2f627ed543bc1750 Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 23:09:08 +0100
-Subject: [PATCH 18/19] Revert "IIO: ti_adc: Correct wrong samples received on
+Subject: [PATCH 18/22] Revert "IIO: ti_adc: Correct wrong samples received on
  1st read in continuous mode"
 
 With a proper fix to this code, this is no longer neccessary.

--- a/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
+++ b/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
@@ -1,0 +1,42 @@
+From 80ad5301e3816b406bed0d0fa6c20c83b1895567 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:09:08 +0100
+Subject: [PATCH 18/19] Revert "IIO: ti_adc: Correct wrong samples received on
+ 1st read in continuous mode"
+
+With a proper fix to this code, this is no longer neccessary.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 21294f2..1f42e0a 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -36,7 +36,6 @@
+ #include <linux/iio/trigger_consumer.h>
+ #include <linux/iio/kfifo_buf.h>
+ #include <linux/iio/sysfs.h>
+-#include <linux/delay.h>
+ 
+ struct tiadc_device {
+ 	struct ti_tscadc_dev *mfd_tscadc;
+@@ -222,13 +221,6 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+-        /*
+-         * Wait for ADC sequencer to settle down.
+-         * There could be a scenario where in we
+-         * try to read data from ADC before
+-         * it is available.
+-         */
+-        udelay(500);
+ 
+         for (i = 0; i < fifo1count; i++) {
+                 readx1 = tiadc_readl(adc_dev, REG_FIFO1);
+-- 
+1.7.9.5
+

--- a/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
+++ b/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
@@ -1,0 +1,38 @@
+From bfa1fadead5bcc80dd429a9cb64966665c7b51a6 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:13:38 +0100
+Subject: [PATCH 19/19] IIO: ti_adc: Fix capture operation during resume
+
+The ADC needs to go through a proper initialization sequence after
+resuming from suspend.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1f42e0a..40eec84 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -588,12 +588,16 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
++        restore = tiadc_readl(adc_dev, REG_CTRL);
++        restore &= ~(CNTRLREG_TSCSSENB);
++        tiadc_writel(adc_dev, REG_CTRL, restore);
++
+     tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+     tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+ 	/* Make sure ADC is powered up */
+-	restore = tiadc_readl(adc_dev, REG_CTRL);
+ 	restore &= ~(CNTRLREG_POWERDOWN);
++        restore |= CNTRLREG_TSCSSENB;
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+ 	return 0;
+-- 
+1.7.9.5
+

--- a/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
+++ b/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
@@ -1,7 +1,7 @@
-From bfa1fadead5bcc80dd429a9cb64966665c7b51a6 Mon Sep 17 00:00:00 2001
+From e04c9bffd8c6abbfcfa373da059487ebd4b6a76d Mon Sep 17 00:00:00 2001
 From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
 Date: Fri, 12 Jul 2013 23:13:38 +0100
-Subject: [PATCH 19/19] IIO: ti_adc: Fix capture operation during resume
+Subject: [PATCH 19/22] IIO: ti_adc: Fix capture operation during resume
 
 The ADC needs to go through a proper initialization sequence after
 resuming from suspend.

--- a/patches/adc/0020-iio-ti_amss5x-adc-Fix-check_patch.pl-issues.patch
+++ b/patches/adc/0020-iio-ti_amss5x-adc-Fix-check_patch.pl-issues.patch
@@ -1,0 +1,517 @@
+From 1c426d57c7a65ae9919d4587209a71545bfead7c Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sat, 13 Jul 2013 12:09:19 +0100
+Subject: [PATCH 20/22] iio: ti_amss5x adc Fix check_patch.pl issues
+
+all clear. replaced printk with pr_info..
+---
+ drivers/iio/adc/ti_am335x_adc.c |  375 ++++++++++++++++++++-------------------
+ 1 file changed, 188 insertions(+), 187 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 40eec84..b1438a7 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -44,9 +44,9 @@ struct tiadc_device {
+ 	u8 channel_step[8];
+ 	struct work_struct      poll_work;
+ 	wait_queue_head_t       wq_data_avail;
+-	int                     irq;
+-	bool                    is_continuous_mode;
+-        u16                     *buffer;
++	int		     irq;
++	bool		    is_continuous_mode;
++	u16		     *buffer;
+ };
+ 
+ static unsigned int tiadc_readl(struct tiadc_device *adc, unsigned int reg)
+@@ -69,7 +69,7 @@ static u32 get_adc_step_mask(struct tiadc_device *adc_dev)
+ 	return step_en;
+ }
+ 
+-static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
++static void tiadc_step_config(struct tiadc_device *adc_dev, bool mode)
+ {
+ 	unsigned int stepconfig;
+ 	int i, steps;
+@@ -86,10 +86,10 @@ static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ 
+ 	steps = TOTAL_STEPS - adc_dev->channels;
+ 	if (mode == 0)
+-            stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++		stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
+ 	else
+-			stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
+-			| STEPCONFIG_MODE_SWCNT;
++		stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
++				| STEPCONFIG_MODE_SWCNT;
+ 
+ 	for (i = 0; i < adc_dev->channels; i++) {
+ 		int chan;
+@@ -106,225 +106,225 @@ static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ }
+ 
+ static ssize_t tiadc_show_mode(struct device *dev,
+-                struct device_attribute *attr, char *buf)
++		struct device_attribute *attr, char *buf)
+ {
+-        struct iio_dev *indio_dev = dev_get_drvdata(dev);
+-        struct tiadc_device *adc_dev = iio_priv(indio_dev);
+-        unsigned int tmp;
+-
+-        tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
+-        tmp &= STEPCONFIG_MODE(1);
+-
+-        if (tmp == 0x00)
+-                return sprintf(buf, "oneshot\n");
+-        else if (tmp == 0x01)
+-                return sprintf(buf, "continuous\n");
+-        else
+-                return sprintf(buf, "Operation mode unknown\n");
++	struct iio_dev *indio_dev = dev_get_drvdata(dev);
++	struct tiadc_device *adc_dev = iio_priv(indio_dev);
++	unsigned int tmp;
++
++	tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
++	tmp &= STEPCONFIG_MODE(1);
++
++	if (tmp == 0x00)
++		return sprintf(buf, "oneshot\n");
++	else if (tmp == 0x01)
++		return sprintf(buf, "continuous\n");
++	else
++		return sprintf(buf, "Operation mode unknown\n");
+ }
+ 
+ static ssize_t tiadc_set_mode(struct device *dev,
+-                struct device_attribute *attr, const char *buf, size_t count)
++		struct device_attribute *attr, const char *buf, size_t count)
+ {
+-        struct iio_dev *indio_dev = dev_get_drvdata(dev);
+-        struct tiadc_device *adc_dev = iio_priv(indio_dev);
+-        unsigned config;
++	struct iio_dev *indio_dev = dev_get_drvdata(dev);
++	struct tiadc_device *adc_dev = iio_priv(indio_dev);
++	unsigned config;
+ 
+-        config = tiadc_readl(adc_dev, REG_CTRL);
+-        config &= ~(CNTRLREG_TSCSSENB);
+-        tiadc_writel(adc_dev, REG_CTRL, config);
++	config = tiadc_readl(adc_dev, REG_CTRL);
++	config &= ~(CNTRLREG_TSCSSENB);
++	tiadc_writel(adc_dev, REG_CTRL, config);
+ 
+ 	if (!strncmp(buf, "oneshot", 7))
+-               adc_dev->is_continuous_mode = false;
+-        else if (!strncmp(buf, "continuous", 10))
+-                adc_dev->is_continuous_mode = true;
+-        else {
+-                dev_err(dev, "Operational mode unknown\n");
+-                return -EINVAL;
+-        }
+- 
++		adc_dev->is_continuous_mode = false;
++	else if (!strncmp(buf, "continuous", 10))
++		adc_dev->is_continuous_mode = true;
++	else {
++		dev_err(dev, "Operational mode unknown\n");
++		return -EINVAL;
++	}
++
+ 	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+-        config = tiadc_readl(adc_dev, REG_CTRL);
+-        tiadc_writel(adc_dev, REG_CTRL,
+-                        (config | CNTRLREG_TSCSSENB));
+-        return count;
++	config = tiadc_readl(adc_dev, REG_CTRL);
++	tiadc_writel(adc_dev, REG_CTRL,
++			(config | CNTRLREG_TSCSSENB));
++	return count;
+ }
+ 
+ static IIO_DEVICE_ATTR(mode, S_IRUGO | S_IWUSR, tiadc_show_mode,
+-                tiadc_set_mode, 0);
++		tiadc_set_mode, 0);
+ 
+ static struct attribute *tiadc_attributes[] = {
+-        &iio_dev_attr_mode.dev_attr.attr,
+-        NULL,
++	&iio_dev_attr_mode.dev_attr.attr,
++	NULL,
+ };
+ 
+ static const struct attribute_group tiadc_attribute_group = {
+-        .attrs = tiadc_attributes,
++	.attrs = tiadc_attributes,
+ };
+ 
+ static irqreturn_t tiadc_irq(int irq, void *private)
+ {
+-        struct iio_dev *idev = private;
+-        struct tiadc_device *adc_dev = iio_priv(idev);
++	struct iio_dev *idev = private;
++	struct tiadc_device *adc_dev = iio_priv(idev);
+ 	unsigned int status, config;
+ 
+-        status = tiadc_readl(adc_dev, REG_IRQSTATUS);
+-        if (status & IRQENB_FIFO1OVRRUN) {
+-                config = tiadc_readl(adc_dev, REG_CTRL);
+-                config &= ~(CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev, REG_CTRL, config);
+-
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW |
+-                                IRQENB_FIFO1THRES);
+- 
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                       (config | CNTRLREG_TSCSSENB));
++	status = tiadc_readl(adc_dev, REG_IRQSTATUS);
++	if (status & IRQENB_FIFO1OVRRUN) {
++		config = tiadc_readl(adc_dev, REG_CTRL);
++		config &= ~(CNTRLREG_TSCSSENB);
++		tiadc_writel(adc_dev, REG_CTRL, config);
++
++		tiadc_writel(adc_dev, REG_IRQSTATUS,
++				IRQENB_FIFO1OVRRUN |
++				IRQENB_FIFO1UNDRFLW |
++				IRQENB_FIFO1THRES);
++
++		tiadc_writel(adc_dev, REG_CTRL,
++		       (config | CNTRLREG_TSCSSENB));
++		return IRQ_HANDLED;
++	} else if (status & IRQENB_FIFO1THRES) {
++		tiadc_writel(adc_dev, REG_IRQCLR,
++				IRQENB_FIFO1THRES);
++
++		if (iio_buffer_enabled(idev)) {
++			if (!work_pending(&adc_dev->poll_work))
++				schedule_work(&adc_dev->poll_work);
++		} else {
++			wake_up_interruptible(&adc_dev->wq_data_avail);
++		}
++
+ 		return IRQ_HANDLED;
+-        } else if (status & IRQENB_FIFO1THRES) {
+-                tiadc_writel(adc_dev, REG_IRQCLR,
+-                                IRQENB_FIFO1THRES);
+-
+-                if (iio_buffer_enabled(idev)) {
+-                        if (!work_pending(&adc_dev->poll_work))
+-                                schedule_work(&adc_dev->poll_work);
+-                } else {
+-                        wake_up_interruptible(&adc_dev->wq_data_avail);
+-                }
+-
+-                return IRQ_HANDLED;      
+ 	} else {
+-                return IRQ_NONE;
+-        }
++		return IRQ_NONE;
++	}
+ }
+ 
+ static void tiadc_poll_handler(struct work_struct *work_s)
+ {
+-        struct tiadc_device *adc_dev =
+-                container_of(work_s, struct tiadc_device, poll_work);
+-        struct iio_dev *idev = iio_priv_to_dev(adc_dev);
+-        struct iio_buffer *buffer = idev->buffer;
+-        unsigned int fifo1count, readx1;
+-        int i;
+-        u32 *iBuf;
+-
+-        fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-        if (fifo1count * sizeof(u32) <
+-                                buffer->access->get_bytes_per_datum(buffer)) {
+-                dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
+-                                                                __func__);
+-                goto out;
+-        }
+-
+-        iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+-        if (iBuf == NULL)
+-                goto out;
+-
+-        for (i = 0; i < fifo1count; i++) {
+-                readx1 = tiadc_readl(adc_dev, REG_FIFO1);
+-                readx1 &= FIFOREAD_DATA_MASK;
+-                iBuf[i] = readx1;
+-        }
+-
+-        buffer->access->store_to(buffer, (u8 *) iBuf);
+-	kfree(iBuf);
+-
+-out:	
++	struct tiadc_device *adc_dev =
++		container_of(work_s, struct tiadc_device, poll_work);
++	struct iio_dev *idev = iio_priv_to_dev(adc_dev);
++	struct iio_buffer *buffer = idev->buffer;
++	unsigned int fifo1count, readx1;
++	int i;
++	u32 *inputbuffer;
++
++	fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++	if (fifo1count * sizeof(u32) <
++				buffer->access->get_bytes_per_datum(buffer)) {
++		dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
++								__func__);
++		goto out;
++	}
++
++	inputbuffer = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
++	if (inputbuffer == NULL)
++		goto out;
++
++	for (i = 0; i < fifo1count; i++) {
++		readx1 = tiadc_readl(adc_dev, REG_FIFO1);
++		readx1 &= FIFOREAD_DATA_MASK;
++		inputbuffer[i] = readx1;
++	}
++
++	buffer->access->store_to(buffer, (u8 *) inputbuffer);
++	kfree(inputbuffer);
++
++out:
+ 	tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 				IRQENB_FIFO1THRES);
+-        tiadc_writel(adc_dev, REG_IRQENABLE, 
++	tiadc_writel(adc_dev, REG_IRQENABLE,
+ 				IRQENB_FIFO1THRES);
+-    
++
+ }
+ 
+ static int tiadc_buffer_preenable(struct iio_dev *idev)
+ {
+-        struct iio_buffer *buffer = idev->buffer;
++	struct iio_buffer *buffer = idev->buffer;
+ 
+-        buffer->access->set_bytes_per_datum(buffer, 16);
+-        return 0;
++	buffer->access->set_bytes_per_datum(buffer, 16);
++	return 0;
+ }
+ 
+ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
+-        struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, config;
+-        int stepnum;
+-        u8 bit;
+-
+-        if (!adc_dev->is_continuous_mode) {
+-                printk("Data cannot be read continuously in one shot mode\n");
+-                return -EINVAL;
+-        } else {
+-
+-                config = tiadc_readl(adc_dev, REG_CTRL);
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                                        config & ~CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                                        config |  CNTRLREG_TSCSSENB);
+-
+-                tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                                 IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW);
+-                tiadc_writel(adc_dev,  REG_IRQENABLE,
+-                                 IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN);
+-
+-                tiadc_writel(adc_dev, REG_SE, 0x00);
+-                for_each_set_bit(bit, buffer->scan_mask,
+-                                adc_dev->channels) {
+-                        struct iio_chan_spec const *chan = idev->channels + bit;
+-                        /*
+-                         * There are a total of 16 steps available
+-                         * that are shared between ADC and touchscreen.
+-                         * We start configuring from step 16 to 0 incase of
+-                         * ADC. Hence the relation between input channel
+-                         * and step for ADC would be as below.
+-                         */
+-                        stepnum = chan->channel + 9;
+-                        enb = tiadc_readl(adc_dev, REG_SE);
+-                        enb |= (1 << stepnum);
+-                        tiadc_writel(adc_dev, REG_SE, enb);
+-                }
+-                return 0;
+-        }
++	struct tiadc_device *adc_dev = iio_priv(idev);
++	struct iio_buffer *buffer = idev->buffer;
++	unsigned int enb, config;
++	int stepnum;
++	u8 bit;
++
++	if (!adc_dev->is_continuous_mode) {
++		pr_info("Data cannot be read continuously in one shot mode\n");
++		return -EINVAL;
++	} else {
++
++		config = tiadc_readl(adc_dev, REG_CTRL);
++		tiadc_writel(adc_dev, REG_CTRL,
++					config & ~CNTRLREG_TSCSSENB);
++		tiadc_writel(adc_dev, REG_CTRL,
++					config |  CNTRLREG_TSCSSENB);
++
++		tiadc_writel(adc_dev,  REG_IRQSTATUS,
++				 IRQENB_FIFO1THRES |
++				 IRQENB_FIFO1OVRRUN |
++				 IRQENB_FIFO1UNDRFLW);
++		tiadc_writel(adc_dev,  REG_IRQENABLE,
++				 IRQENB_FIFO1THRES |
++				 IRQENB_FIFO1OVRRUN);
++
++		tiadc_writel(adc_dev, REG_SE, 0x00);
++		for_each_set_bit(bit, buffer->scan_mask,
++				adc_dev->channels) {
++			struct iio_chan_spec const *chan = idev->channels + bit;
++			/*
++			 * There are a total of 16 steps available
++			 * that are shared between ADC and touchscreen.
++			 * We start configuring from step 16 to 0 incase of
++			 * ADC. Hence the relation between input channel
++			 * and step for ADC would be as below.
++			 */
++			stepnum = chan->channel + 9;
++			enb = tiadc_readl(adc_dev, REG_SE);
++			enb |= (1 << stepnum);
++			tiadc_writel(adc_dev, REG_SE, enb);
++		}
++		return 0;
++	}
+ }
+ 
+ static int tiadc_buffer_postdisable(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
+-  
++	struct tiadc_device *adc_dev = iio_priv(idev);
++
+ 	tiadc_writel(adc_dev, REG_IRQCLR, (IRQENB_FIFO1THRES |
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW));
+-        tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
+-        return 0;
++				IRQENB_FIFO1OVRRUN |
++				IRQENB_FIFO1UNDRFLW));
++	tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
++	return 0;
+ }
+ 
+ static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
+-        .preenable = &tiadc_buffer_preenable,
+-        .postenable = &tiadc_buffer_postenable,
+-        .postdisable = &tiadc_buffer_postdisable,
++	.preenable = &tiadc_buffer_preenable,
++	.postenable = &tiadc_buffer_postenable,
++	.postdisable = &tiadc_buffer_postdisable,
+ };
+ 
+ static int tiadc_config_sw_ring(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
++	struct tiadc_device *adc_dev = iio_priv(idev);
+ 
+-        idev->buffer = iio_kfifo_allocate(idev);
+-        if (!idev->buffer)
+-                return(-ENOMEM);
++	idev->buffer = iio_kfifo_allocate(idev);
++	if (!idev->buffer)
++		return -ENOMEM;
+ 
+-        idev->setup_ops = &tiadc_buffer_setup_ops;
++	idev->setup_ops = &tiadc_buffer_setup_ops;
+ 
+-        INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
++	INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
+ 
+-        idev->modes |= INDIO_BUFFER_HARDWARE;
+-        return 0;
++	idev->modes |= INDIO_BUFFER_HARDWARE;
++	return 0;
+ }
+ 
+ static const char * const chan_name_ain[] = {
+@@ -389,14 +389,14 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 	unsigned long timeout = jiffies + usecs_to_jiffies
+ 				(IDLE_TIMEOUT * adc_dev->channels);
+ 
+-       if (adc_dev->is_continuous_mode) {
+-               printk("One shot mode not enabled\n");
+-               return -EINVAL;
+-       } else {
++	if (adc_dev->is_continuous_mode) {
++		pr_info("One shot mode not enabled\n");
++		return -EINVAL;
++	} else {
+ 
+ 		step_en = get_adc_step_mask(adc_dev);
+ 		am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
+-	 
++
+ 		/* Wait for ADC sequencer to complete sampling */
+ 		while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
+ 			if (time_after(jiffies, timeout))
+@@ -437,16 +437,17 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 			}
+ 		}
+ 
+-		switch (mask){
+-			case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
++		switch (mask) {
++		case IIO_CHAN_INFO_RAW: /*Do nothing. Above code works fine.*/
+ 						break;
+-			case IIO_CHAN_INFO_SCALE : {
+-				/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
+-				AVDD should come from DT.*/
+-				*val = div_u64( (u64)(*val) * 1800 , 4096);
++		case IIO_CHAN_INFO_SCALE: {
++			/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
++			AVDD should come from DT.*/
++				*val = div_u64((u64)(*val) * 1800 , 4096);
+ 				break;
+ 			}
+-			default: break;
++		default:
++			break;
+ 		}
+ 
+ 		if (found == false)
+@@ -518,7 +519,7 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	err = tiadc_config_sw_ring(indio_dev);
+ 	if (err < 0)
+ 		goto err_unregister;
+- 
++
+ 	err = iio_buffer_register(indio_dev,
+ 		indio_dev->channels, indio_dev->num_channels);
+ 	if (err < 0)
+@@ -588,16 +589,16 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
+-        restore = tiadc_readl(adc_dev, REG_CTRL);
+-        restore &= ~(CNTRLREG_TSCSSENB);
+-        tiadc_writel(adc_dev, REG_CTRL, restore);
++	restore = tiadc_readl(adc_dev, REG_CTRL);
++	restore &= ~(CNTRLREG_TSCSSENB);
++	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+-    tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+-    tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++	tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+ 	/* Make sure ADC is powered up */
+ 	restore &= ~(CNTRLREG_POWERDOWN);
+-        restore |= CNTRLREG_TSCSSENB;
++	restore |= CNTRLREG_TSCSSENB;
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+ 	return 0;
+-- 
+1.7.9.5
+

--- a/patches/adc/0021-input-ti_am335x_tsc.c-fix-checkpatch.pl-issues.patch
+++ b/patches/adc/0021-input-ti_am335x_tsc.c-fix-checkpatch.pl-issues.patch
@@ -1,0 +1,59 @@
+From 08c6e9713f471f54088ff10b7ce50e78dfc5b134 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sun, 14 Jul 2013 12:05:15 +0100
+Subject: [PATCH 21/22] input: ti_am335x_tsc.c fix checkpatch.pl issues
+
+code formatting fixes
+---
+ drivers/input/touchscreen/ti_am335x_tsc.c |   28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index 4bf2ee6..ba7abfe 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -260,19 +260,19 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	unsigned int fsm;
+ 
+ 	status = titsc_readl(ts_dev, REG_IRQSTATUS);
+- 
+-        /*
+-         * ADC and touchscreen share the IRQ line.
+-         * FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
+-         * interrupts are used by ADC,
+-         * hence return from touchscreen IRQ handler if FIFO1
+-         * related interrupts occurred.
+-         */
+-       if ((status & IRQENB_FIFO1THRES) ||
+-                       (status & IRQENB_FIFO1OVRRUN) ||
+-                       (status & IRQENB_FIFO1UNDRFLW))
+-                return IRQ_NONE;
+-        else if (status & IRQENB_FIFO0THRES) {
++
++	/*
++	* ADC and touchscreen share the IRQ line.
++	* FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
++	* interrupts are used by ADC,
++	* hence return from touchscreen IRQ handler if FIFO1
++	* related interrupts occurred.
++	*/
++	if ((status & IRQENB_FIFO1THRES) ||
++			(status & IRQENB_FIFO1OVRRUN) ||
++			(status & IRQENB_FIFO1UNDRFLW))
++		return IRQ_NONE;
++	else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+ 
+ 		if (ts_dev->pen_down && z1 != 0 && z2 != 0) {
+@@ -326,7 +326,7 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	}
+ 
+ 	if (irqclr) {
+-		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr) );
++		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr));
+ 		am335x_tsc_se_update(ts_dev->mfd_tscadc);
+ 		return IRQ_HANDLED;
+ 	}
+-- 
+1.7.9.5
+

--- a/patches/adc/0022-mfd-ti_am335x_tscadc.c-fix-checkpatch.pl-issues.patch
+++ b/patches/adc/0022-mfd-ti_am335x_tscadc.c-fix-checkpatch.pl-issues.patch
@@ -1,0 +1,37 @@
+From 4cdd9b71995fab0caaaec3000f0eb19faf606780 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sun, 14 Jul 2013 12:06:52 +0100
+Subject: [PATCH 22/22] mfd: ti_am335x_tscadc.c fix checkpatch.pl issues
+
+code formatting corrected.
+---
+ drivers/mfd/ti_am335x_tscadc.c |    6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index e7314e4..b8d7dfb 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -278,8 +278,8 @@ static int tscadc_suspend(struct device *dev)
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+ 
+ 	tscadc_writel(tscadc_dev, REG_SE, 0x00);
+-        tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
+-        tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
++	tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
++	tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
+ 	pm_runtime_put_sync(dev);
+ 
+ 	return 0;
+@@ -297,7 +297,7 @@ static int tscadc_resume(struct device *dev)
+ 	if (tscadc_dev->tsc_cell != -1)
+ 		tscadc_idle_config(tscadc_dev);
+ 	am335x_tsc_se_update(tscadc_dev);
+-        tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
++	tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
+ 
+ 	return 0;
+ }
+-- 
+1.7.9.5
+

--- a/patches/mainline-capemgr/0001-capemgr-Capemgr-makefiles-and-Kconfig-fragments.patch
+++ b/patches/mainline-capemgr/0001-capemgr-Capemgr-makefiles-and-Kconfig-fragments.patch
@@ -1,4 +1,4 @@
-From 418e22259a0ea37208d678faae7094573b0d3f05 Mon Sep 17 00:00:00 2001
+From 4bd37193d877f3c7e238161d9be49ef1dbd94e44 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Dec 2012 20:56:48 +0200
 Subject: [PATCH 01/11] capemgr: Capemgr makefiles and Kconfig fragments.
@@ -10,13 +10,13 @@ Makefile and Kconfig fragments.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/mach-omap2/Kconfig           |  2 ++
- drivers/misc/Kconfig                  |  2 ++
- drivers/misc/Makefile                 |  1 +
- drivers/misc/cape/Kconfig             |  5 +++++
- drivers/misc/cape/Makefile            |  5 +++++
- drivers/misc/cape/beaglebone/Kconfig  | 11 +++++++++++
- drivers/misc/cape/beaglebone/Makefile |  5 +++++
+ arch/arm/mach-omap2/Kconfig           |    2 ++
+ drivers/misc/Kconfig                  |    2 ++
+ drivers/misc/Makefile                 |    1 +
+ drivers/misc/cape/Kconfig             |    5 +++++
+ drivers/misc/cape/Makefile            |    5 +++++
+ drivers/misc/cape/beaglebone/Kconfig  |   11 +++++++++++
+ drivers/misc/cape/beaglebone/Makefile |    5 +++++
  7 files changed, 31 insertions(+)
  create mode 100644 drivers/misc/cape/Kconfig
  create mode 100644 drivers/misc/cape/Makefile
@@ -107,5 +107,5 @@ index 0000000..5b4549f
 +
 +obj-$(CONFIG_CAPE_BEAGLEBONE)		+= capemgr.o
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0002-capemgr-Beaglebone-capemanager.patch
+++ b/patches/mainline-capemgr/0002-capemgr-Beaglebone-capemanager.patch
@@ -1,4 +1,4 @@
-From d1b1cd2bcbc34ccc853c5f1b472b9102a68caca5 Mon Sep 17 00:00:00 2001
+From 9167f6dd8d4c49e79395b06b86d793bbef1e7a1e Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Dec 2012 21:00:31 +0200
 Subject: [PATCH 02/11] capemgr: Beaglebone capemanager
@@ -1855,5 +1855,5 @@ index 0000000..651f48d
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS("platform:bone_capemgr");
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0003-capemgr-Remove-__devinit-__devexit.patch
+++ b/patches/mainline-capemgr/0003-capemgr-Remove-__devinit-__devexit.patch
@@ -1,4 +1,4 @@
-From eb12b368fa659f0deb50349746179e7ab838fb1a Mon Sep 17 00:00:00 2001
+From c1235564e3234298f1d15136651786d828708a81 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 15 Jan 2013 14:15:00 +0200
 Subject: [PATCH 03/11] capemgr: Remove __devinit/__devexit
@@ -7,7 +7,7 @@ __devinit/__devexit and the like has been purged. Remove them.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 6 +++---
+ drivers/misc/cape/beaglebone/capemgr.c |    6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -42,5 +42,5 @@ index 651f48d..d828af7 100644
  		.name	= "bone-capemgr",
  		.owner	= THIS_MODULE,
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0004-bone-capemgr-Make-sure-cape-removal-works.patch
+++ b/patches/mainline-capemgr/0004-bone-capemgr-Make-sure-cape-removal-works.patch
@@ -1,4 +1,4 @@
-From 97097e3663524c27e554c69a4ef7afd6e827722a Mon Sep 17 00:00:00 2001
+From e112f20833801687acdf427740c8444544f3eca6 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Wed, 27 Feb 2013 11:32:20 +0200
 Subject: [PATCH 04/11] bone-capemgr: Make sure cape removal works.
@@ -7,7 +7,7 @@ Cape removal wasn't working properly before; fix it.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 62 ++++++++++++++++++++++++----------
+ drivers/misc/cape/beaglebone/capemgr.c |   62 +++++++++++++++++++++++---------
  1 file changed, 45 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -109,5 +109,5 @@ index d828af7..2656e3a 100644
  
  	bone_capemgr_info_sysfs_unregister(info);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0005-bone-capemgr-Fix-crash-when-trying-to-remove-non-exi.patch
+++ b/patches/mainline-capemgr/0005-bone-capemgr-Fix-crash-when-trying-to-remove-non-exi.patch
@@ -1,4 +1,4 @@
-From a0f8848100b641f5d226886ba9c44b063f142089 Mon Sep 17 00:00:00 2001
+From c2f852a5eb6b5c4ce987c271dd76b0a2c26f962b Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Wed, 27 Feb 2013 18:35:09 +0200
 Subject: [PATCH 05/11] bone-capemgr: Fix crash when trying to remove
@@ -8,7 +8,7 @@ Wrong test for not-found case lead to crash. Fix.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 11 ++++-------
+ drivers/misc/cape/beaglebone/capemgr.c |   11 ++++-------
  1 file changed, 4 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -36,5 +36,5 @@ index 2656e3a..9f8da94 100644
  		mutex_unlock(&info->slots_list_mutex);
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0006-bone-capemgr-Force-a-slot-to-load-unconditionally.patch
+++ b/patches/mainline-capemgr/0006-bone-capemgr-Force-a-slot-to-load-unconditionally.patch
@@ -1,4 +1,4 @@
-From cff4eb30e185e0d238f4e5446bd6df634e044fdb Mon Sep 17 00:00:00 2001
+From ddcd520a9ac3d945e2d919a056bc802d9f5e306c Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 8 Mar 2013 14:31:40 +0200
 Subject: [PATCH 06/11] bone-capemgr: Force a slot to load unconditionally
@@ -8,7 +8,7 @@ Useful for testing.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 4 ++++
+ drivers/misc/cape/beaglebone/capemgr.c |    4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -27,5 +27,5 @@ index 9f8da94..255c491 100644
  	if (extra_override == NULL)
  		return 0;
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0007-capemgr-Added-module-param-descriptions.patch
+++ b/patches/mainline-capemgr/0007-capemgr-Added-module-param-descriptions.patch
@@ -1,4 +1,4 @@
-From 007acfcc1c26c413beaf2526488f7325088ec4c6 Mon Sep 17 00:00:00 2001
+From 278a9461eb146a9b4cb6ee626ed70adc327a6f35 Mon Sep 17 00:00:00 2001
 From: Matt Ranostay <mranostay@gmail.com>
 Date: Tue, 19 Mar 2013 17:05:02 +0000
 Subject: [PATCH 07/11] capemgr: Added module param descriptions
@@ -7,7 +7,7 @@ Added a simple MODULE_PARM_DESC for the extra_override option
 
 Signed-off-by: Matt Ranostay <mranostay@gmail.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 1 +
+ drivers/misc/cape/beaglebone/capemgr.c |    1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -23,5 +23,5 @@ index 255c491..2ee7b11 100644
  struct bone_capemgr_info;
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0008-capemgr-Implement-disable-overrides-on-the-cmd-line.patch
+++ b/patches/mainline-capemgr/0008-capemgr-Implement-disable-overrides-on-the-cmd-line.patch
@@ -1,4 +1,4 @@
-From a397c66e17b85324f6a13b21ead5a5bd09fc1ed2 Mon Sep 17 00:00:00 2001
+From db3330ceb5c66a93c6649fee3a032e4d2142d047 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Mon, 1 Apr 2013 18:20:35 +0300
 Subject: [PATCH 08/11] capemgr: Implement disable overrides on the cmd line
@@ -7,7 +7,7 @@ Allow capes to be disabled on the kernel command line.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 133 ++++++++++++++++++++++-----------
+ drivers/misc/cape/beaglebone/capemgr.c |  133 +++++++++++++++++++++-----------
  1 file changed, 88 insertions(+), 45 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -218,5 +218,5 @@ index 2ee7b11..5d87088 100644
  			slot->loading = 1;
  			slot->loader_thread = kthread_run(bone_capemgr_loader,
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0009-capemgr-Implement-cape-priorities.patch
+++ b/patches/mainline-capemgr/0009-capemgr-Implement-cape-priorities.patch
@@ -1,4 +1,4 @@
-From 0fff268a344ceaf0f5ea28c4e7a1baf229611713 Mon Sep 17 00:00:00 2001
+From ed60bd97a50c7a8804aea1c52ddb4e5967e35bff Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Mon, 22 Apr 2013 17:11:17 +0300
 Subject: [PATCH 09/11] capemgr: Implement cape priorities
@@ -9,7 +9,7 @@ loaded.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 139 ++++++++++++++++++++++++++++-----
+ drivers/misc/cape/beaglebone/capemgr.c |  139 +++++++++++++++++++++++++++-----
  1 file changed, 119 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -276,5 +276,5 @@ index 5d87088..820852d 100644
  
  	bone_capemgr_info_sysfs_unregister(info);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0010-bone-capemgr-Introduce-simple-resource-tracking.patch
+++ b/patches/mainline-capemgr/0010-bone-capemgr-Introduce-simple-resource-tracking.patch
@@ -1,4 +1,4 @@
-From 5f0f79c58005d26be34dad809ff9c95fc368a504 Mon Sep 17 00:00:00 2001
+From f4fc59c4c1a21751709d0c85e3d7f52424d4af8a Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 16 May 2013 18:11:19 +0300
 Subject: [PATCH 10/11] bone: capemgr: Introduce simple resource tracking
@@ -7,7 +7,7 @@ Now each cape can declare an exclusive-use property which is
 a string list of every resource it requires.
 Attempting to load a cape that uses the same resource will fail.
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 127 ++++++++++++++++++++++++++++++++-
+ drivers/misc/cape/beaglebone/capemgr.c |  127 +++++++++++++++++++++++++++++++-
  1 file changed, 125 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -163,5 +163,5 @@ index 820852d..2820e39 100644
  	/* we're done, wake up all */
  	wake_up_interruptible_all(&info->load_wq);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-capemgr/0011-capemgr-Add-enable_partno-parameter.patch
+++ b/patches/mainline-capemgr/0011-capemgr-Add-enable_partno-parameter.patch
@@ -1,4 +1,4 @@
-From a30f200c1337c2b674aa0e3d7df77e1dff45ea31 Mon Sep 17 00:00:00 2001
+From 7917ea95b2b5a1d850dcfda811b18dcfb9a2b08f Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 4 Jun 2013 19:42:45 +0300
 Subject: [PATCH 11/11] capemgr: Add enable_partno parameter
@@ -8,7 +8,7 @@ a base dts override.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/cape/beaglebone/capemgr.c | 66 ++++++++++++++++++++++++++++++++++
+ drivers/misc/cape/beaglebone/capemgr.c |   66 ++++++++++++++++++++++++++++++++
  1 file changed, 66 insertions(+)
 
 diff --git a/drivers/misc/cape/beaglebone/capemgr.c b/drivers/misc/cape/beaglebone/capemgr.c
@@ -114,5 +114,5 @@ index 2820e39..b1a8b65 100644
  
  		/* if matches the disabled ones skip */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0001-ARM-davinci-move-private-EDMA-API-to-arm-common.patch
+++ b/patches/mainline-dma-devel/0001-ARM-davinci-move-private-EDMA-API-to-arm-common.patch
@@ -1,4 +1,4 @@
-From dcb04438784ea10976bffb726135d40aa62ffba2 Mon Sep 17 00:00:00 2001
+From 456320c6eabd43488bc1831004be92b08a388e89 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 11:15:31 -0500
 Subject: [PATCH 01/20] ARM: davinci: move private EDMA API to arm/common
@@ -3993,5 +3993,5 @@ index b6ef703..fbb710c 100644
  struct davinci_pcm_dma_params {
  	int channel;			/* sync dma channel ID */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0002-ARM-edma-remove-unused-transfer-controller-handlers.patch
+++ b/patches/mainline-dma-devel/0002-ARM-edma-remove-unused-transfer-controller-handlers.patch
@@ -1,4 +1,4 @@
-From d8cf9859d05bea3d8bd8c24b21bf2e0a187d6e32 Mon Sep 17 00:00:00 2001
+From a2cbf08177cf827e0894b8b30cd82492e46e06a2 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 11:15:32 -0500
 Subject: [PATCH 02/20] ARM: edma: remove unused transfer controller handlers
@@ -10,7 +10,7 @@ so since they are unused code, simply remove them.
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Sekhar Nori <nsekhar@ti.com>
 ---
- arch/arm/common/edma.c | 37 -------------------------------------
+ arch/arm/common/edma.c |   37 -------------------------------------
  1 file changed, 37 deletions(-)
 
 diff --git a/arch/arm/common/edma.c b/arch/arm/common/edma.c
@@ -69,5 +69,5 @@ index dcaeb8e..a1db6cd 100644
  
  fail:
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0003-ARM-edma-Convert-to-devm_-api.patch
+++ b/patches/mainline-dma-devel/0003-ARM-edma-Convert-to-devm_-api.patch
@@ -1,4 +1,4 @@
-From 0cfbb732b071746c7432eb648b651f941601778e Mon Sep 17 00:00:00 2001
+From a109c7c14efdbaea770d4896d2931594bcb436f0 Mon Sep 17 00:00:00 2001
 From: "Lad, Prabhakar" <prabhakar.csengg@gmail.com>
 Date: Mon, 17 Jun 2013 20:27:58 +0530
 Subject: [PATCH 03/20] ARM: edma: Convert to devm_* api
@@ -13,7 +13,7 @@ Signed-off-by: Lad, Prabhakar <prabhakar.csengg@gmail.com>
 [nsekhar@ti.com: add missing err.h include]
 Signed-off-by: Sekhar Nori <nsekhar@ti.com>
 ---
- arch/arm/common/edma.c | 65 ++++++++++++++++----------------------------------
+ arch/arm/common/edma.c |   65 +++++++++++++++---------------------------------
  1 file changed, 20 insertions(+), 45 deletions(-)
 
 diff --git a/arch/arm/common/edma.c b/arch/arm/common/edma.c
@@ -131,5 +131,5 @@ index a1db6cd..7658874 100644
  
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0004-ARM-davinci-uart-move-to-devid-based-clk_get.patch
+++ b/patches/mainline-dma-devel/0004-ARM-davinci-uart-move-to-devid-based-clk_get.patch
@@ -1,4 +1,4 @@
-From 9f93fcd0417b0d21b793629df4f694de09a12bc0 Mon Sep 17 00:00:00 2001
+From 6c6eafeb79176e0676ee7451aaa7302d6764bdd0 Mon Sep 17 00:00:00 2001
 From: "Manjunathappa, Prakash" <prakash.pm@ti.com>
 Date: Wed, 19 Jun 2013 14:45:38 +0530
 Subject: [PATCH 04/20] ARM: davinci: uart: move to devid based clk_get
@@ -12,18 +12,18 @@ platform_device_register for each instance and clk_get on dev_id.
 Signed-off-by: Manjunathappa, Prakash <prakash.pm@ti.com>
 Signed-off-by: Sekhar Nori <nsekhar@ti.com>
 ---
- arch/arm/mach-davinci/da830.c                  |  8 ++--
- arch/arm/mach-davinci/da850.c                  |  8 ++--
- arch/arm/mach-davinci/devices-da8xx.c          | 42 +++++++++++++++++----
- arch/arm/mach-davinci/devices-tnetv107x.c      | 37 +++++++++++++++---
- arch/arm/mach-davinci/dm355.c                  | 52 ++++++++++++++++++++------
- arch/arm/mach-davinci/dm365.c                  | 38 +++++++++++++------
- arch/arm/mach-davinci/dm644x.c                 | 52 ++++++++++++++++++++------
- arch/arm/mach-davinci/dm646x.c                 | 52 ++++++++++++++++++++------
- arch/arm/mach-davinci/include/mach/da8xx.h     |  2 +-
- arch/arm/mach-davinci/include/mach/tnetv107x.h |  2 +-
- arch/arm/mach-davinci/serial.c                 | 19 ++++++----
- arch/arm/mach-davinci/tnetv107x.c              |  8 ++--
+ arch/arm/mach-davinci/da830.c                  |    8 ++--
+ arch/arm/mach-davinci/da850.c                  |    8 ++--
+ arch/arm/mach-davinci/devices-da8xx.c          |   42 +++++++++++++++----
+ arch/arm/mach-davinci/devices-tnetv107x.c      |   37 ++++++++++++++---
+ arch/arm/mach-davinci/dm355.c                  |   52 ++++++++++++++++++------
+ arch/arm/mach-davinci/dm365.c                  |   38 ++++++++++++-----
+ arch/arm/mach-davinci/dm644x.c                 |   52 ++++++++++++++++++------
+ arch/arm/mach-davinci/dm646x.c                 |   52 ++++++++++++++++++------
+ arch/arm/mach-davinci/include/mach/da8xx.h     |    2 +-
+ arch/arm/mach-davinci/include/mach/tnetv107x.h |    2 +-
+ arch/arm/mach-davinci/serial.c                 |   19 +++++----
+ arch/arm/mach-davinci/tnetv107x.c              |    8 ++--
  12 files changed, 239 insertions(+), 81 deletions(-)
 
 diff --git a/arch/arm/mach-davinci/da830.c b/arch/arm/mach-davinci/da830.c
@@ -720,5 +720,5 @@ index 3b2a70d..d8a9516 100644
  
  void __init tnetv107x_init(void)
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0005-dmaengine-edma-Add-TI-EDMA-device-tree-binding.patch
+++ b/patches/mainline-dma-devel/0005-dmaengine-edma-Add-TI-EDMA-device-tree-binding.patch
@@ -1,4 +1,4 @@
-From 3fcc6b127d6888735600aea523dd46f58bd283ce Mon Sep 17 00:00:00 2001
+From b844dd2c94c56d66fb0a26cba78df000d27e4d1b Mon Sep 17 00:00:00 2001
 From: Matt Porter <mdp@ti.com>
 Date: Thu, 20 Jun 2013 16:06:37 -0500
 Subject: [PATCH 05/20] dmaengine: edma: Add TI EDMA device tree binding
@@ -18,7 +18,7 @@ Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 Signed-off-by: Sekhar Nori <nsekhar@ti.com>
 ---
- Documentation/devicetree/bindings/dma/ti-edma.txt | 34 +++++++++++++++++++++++
+ Documentation/devicetree/bindings/dma/ti-edma.txt |   34 +++++++++++++++++++++
  1 file changed, 34 insertions(+)
  create mode 100644 Documentation/devicetree/bindings/dma/ti-edma.txt
 
@@ -63,5 +63,5 @@ index 0000000..9fbbdb7
 +				  2 13>;
 +};
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0006-ARM-edma-Add-DT-and-runtime-PM-support-to-the-privat.patch
+++ b/patches/mainline-dma-devel/0006-ARM-edma-Add-DT-and-runtime-PM-support-to-the-privat.patch
@@ -1,8 +1,8 @@
-From 3d389cbe8c83496030790268dbb7c82e97e93767 Mon Sep 17 00:00:00 2001
+From 3adb4e791fa2f44df147585ed7ea9528abd7cf22 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 20 Jun 2013 16:06:38 -0500
-Subject: [PATCH 06/20] ARM: edma: Add DT and runtime PM support to the private
- EDMA API
+Subject: [PATCH 06/20] ARM: edma: Add DT and runtime PM support to the
+ private EDMA API
 
 Adds support for parsing the TI EDMA DT data into the required EDMA
 private API platform data. Enables runtime PM support to initialize
@@ -22,14 +22,14 @@ edma_setup_info_from_dt() as part of that effort]
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 Acked-by: Arnd Bergmann <arnd@arndb.de>
 ---
- arch/arm/common/edma.c                    | 186 +++++++++++++++++++++++++++---
- arch/arm/mach-davinci/devices-da8xx.c     |   8 +-
- arch/arm/mach-davinci/devices-tnetv107x.c |   4 +-
- arch/arm/mach-davinci/dm355.c             |   4 +-
- arch/arm/mach-davinci/dm365.c             |   4 +-
- arch/arm/mach-davinci/dm644x.c            |   4 +-
- arch/arm/mach-davinci/dm646x.c            |   4 +-
- include/linux/platform_data/edma.h        |   4 +-
+ arch/arm/common/edma.c                    |  186 +++++++++++++++++++++++++++--
+ arch/arm/mach-davinci/devices-da8xx.c     |    8 +-
+ arch/arm/mach-davinci/devices-tnetv107x.c |    4 +-
+ arch/arm/mach-davinci/dm355.c             |    4 +-
+ arch/arm/mach-davinci/dm365.c             |    4 +-
+ arch/arm/mach-davinci/dm644x.c            |    4 +-
+ arch/arm/mach-davinci/dm646x.c            |    4 +-
+ include/linux/platform_data/edma.h        |    4 +-
  8 files changed, 189 insertions(+), 29 deletions(-)
 
 diff --git a/arch/arm/common/edma.c b/arch/arm/common/edma.c
@@ -445,5 +445,5 @@ index 2344ea2..317f2be 100644
  
  #endif
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0007-ARM-edma-Add-EDMA-crossbar-event-mux-support.patch
+++ b/patches/mainline-dma-devel/0007-ARM-edma-Add-EDMA-crossbar-event-mux-support.patch
@@ -1,4 +1,4 @@
-From 356c51fa7b4ea84dd9fb473b5e26dd846ecc0049 Mon Sep 17 00:00:00 2001
+From 3be8b0e6a3562c05210ce5e7bb167ae9f6342153 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 20 Jun 2013 16:06:39 -0500
 Subject: [PATCH 07/20] ARM: edma: Add EDMA crossbar event mux support
@@ -23,8 +23,8 @@ Acked-by: Arnd Bergmann <arnd@arndb.de>
 [nsekhar@ti.com: fix checkpatch errors and a minor coding improvement]
 Signed-off-by: Sekhar Nori <nsekhar@ti.com>
 ---
- arch/arm/common/edma.c             | 78 ++++++++++++++++++++++++++++++++++++++
- include/linux/platform_data/edma.h |  1 +
+ arch/arm/common/edma.c             |   78 ++++++++++++++++++++++++++++++++++++
+ include/linux/platform_data/edma.h |    1 +
  2 files changed, 79 insertions(+)
 
 diff --git a/arch/arm/common/edma.c b/arch/arm/common/edma.c
@@ -156,5 +156,5 @@ index 317f2be..57300fd 100644
  
  #endif
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0008-dma-edma-add-device_slave_sg_limits-support.patch
+++ b/patches/mainline-dma-devel/0008-dma-edma-add-device_slave_sg_limits-support.patch
@@ -1,4 +1,4 @@
-From 34f0adba9955d4c5930915a7101d171fc20bbcaf Mon Sep 17 00:00:00 2001
+From c6e6a74dbb3a7f88b627fec8842ca9bcdfd756da Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 19:56:06 +0000
 Subject: [PATCH 08/20] dma: edma: add device_slave_sg_limits() support
@@ -19,7 +19,7 @@ the maximum segment length.
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- drivers/dma/edma.c | 17 +++++++++++++++++
+ drivers/dma/edma.c |   17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/drivers/dma/edma.c b/drivers/dma/edma.c
@@ -72,5 +72,5 @@ index 5f3e532..e008ed2 100644
  	dma->device_control = edma_control;
  	dma->dev = dev;
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0009-dmaengine-add-dma_get_slave_sg_limits.patch
+++ b/patches/mainline-dma-devel/0009-dmaengine-add-dma_get_slave_sg_limits.patch
@@ -1,4 +1,4 @@
-From 39c04a16073a3040e918ddea0e974183df426f7c Mon Sep 17 00:00:00 2001
+From 2ec5ce4a6cd21813b48dbd7876d79cfeda32ffd5 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 19:56:05 +0000
 Subject: [PATCH 09/20] dmaengine: add dma_get_slave_sg_limits()
@@ -15,7 +15,7 @@ that the given channel can handle.
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- include/linux/dmaengine.h | 39 +++++++++++++++++++++++++++++++++++++++
+ include/linux/dmaengine.h |   39 +++++++++++++++++++++++++++++++++++++++
  1 file changed, 39 insertions(+)
 
 diff --git a/include/linux/dmaengine.h b/include/linux/dmaengine.h
@@ -90,5 +90,5 @@ index 96d3e4a..3d56a57 100644
  #ifdef CONFIG_DMA_ENGINE
  enum dma_status dma_wait_for_async_tx(struct dma_async_tx_descriptor *tx);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0010-mmc-omap_hsmmc-set-max_segs-based-on-dma-engine-limi.patch
+++ b/patches/mainline-dma-devel/0010-mmc-omap_hsmmc-set-max_segs-based-on-dma-engine-limi.patch
@@ -1,4 +1,4 @@
-From c5550b1b4488a440c1c3912f0f5213235228e9e7 Mon Sep 17 00:00:00 2001
+From 83668b62dbcaf67c25cb96793b4d847465b99e55 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 7 Mar 2013 04:16:38 +0000
 Subject: [PATCH 10/20] mmc: omap_hsmmc: set max_segs based on dma engine
@@ -14,7 +14,7 @@ appropriately.
 Signed-off-by: Matt Porter <mporter@ti.com>
 Acked-by: Tony Lindgren <tony@atomide.com>
 ---
- drivers/mmc/host/omap_hsmmc.c | 8 ++++++++
+ drivers/mmc/host/omap_hsmmc.c |    8 ++++++++
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
@@ -44,5 +44,5 @@ index eccedc7..efe9cc9 100644
  	ret = request_irq(host->irq, omap_hsmmc_irq, 0,
  			mmc_hostname(mmc), host);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0011-dmaengine-edma-enable-build-for-AM33XX.patch
+++ b/patches/mainline-dma-devel/0011-dmaengine-edma-enable-build-for-AM33XX.patch
@@ -1,4 +1,4 @@
-From 273b8912e76dc266cda445e9c789bc9d8bca9c65 Mon Sep 17 00:00:00 2001
+From 2e4c2350dbf4e4a7bd63e6659850fd4743ab4319 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 16:15:34 +0000
 Subject: [PATCH 11/20] dmaengine: edma: enable build for AM33XX
@@ -8,8 +8,8 @@ Enable TI EDMA option on OMAP and TI_PRIV_EDMA
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/mach-omap2/Kconfig | 1 +
- drivers/dma/Kconfig         | 2 +-
+ arch/arm/mach-omap2/Kconfig |    1 +
+ drivers/dma/Kconfig         |    2 +-
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/mach-omap2/Kconfig b/arch/arm/mach-omap2/Kconfig
@@ -38,5 +38,5 @@ index e992489..3215a3c 100644
  	select DMA_VIRTUAL_CHANNELS
  	default n
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0012-da8xx-config-Enable-MMC-and-FS-options.patch
+++ b/patches/mainline-dma-devel/0012-da8xx-config-Enable-MMC-and-FS-options.patch
@@ -1,4 +1,4 @@
-From 2c070cf59744c0226624367a0ebca07328c2a832 Mon Sep 17 00:00:00 2001
+From 7d495c29c0f3bce6e1fb887aea1faeb95b1c09c1 Mon Sep 17 00:00:00 2001
 From: Joel A Fernandes <agnel.joel@gmail.com>
 Date: Thu, 20 Jun 2013 15:07:40 -0500
 Subject: [PATCH 12/20] da8xx: config: Enable MMC and FS options
@@ -7,7 +7,7 @@ Required to get OMAP-L1 EVM access MMC and mount rootfs
 
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/configs/da8xx_omapl_defconfig | 3 +++
+ arch/arm/configs/da8xx_omapl_defconfig |    3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/arm/configs/da8xx_omapl_defconfig b/arch/arm/configs/da8xx_omapl_defconfig
@@ -29,5 +29,5 @@ index 7c86813..35919ca 100644
 +CONFIG_MMC=y
 +CONFIG_MMC_DAVINCI=y
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0013-spi-omap2-mcspi-add-generic-DMA-request-support-to-t.patch
+++ b/patches/mainline-dma-devel/0013-spi-omap2-mcspi-add-generic-DMA-request-support-to-t.patch
@@ -1,4 +1,4 @@
-From fec784bf1a9f1f5195f6e95bf3de684833e41dab Mon Sep 17 00:00:00 2001
+From d9cbfd870d037018e3cb304be5c1889f4ae89fd0 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Wed, 6 Mar 2013 16:15:38 +0000
 Subject: [PATCH 13/20] spi: omap2-mcspi: add generic DMA request support to
@@ -9,7 +9,7 @@ The binding definition is based on the generic DMA request binding
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- Documentation/devicetree/bindings/spi/omap-spi.txt | 27 +++++++++++++++++++++-
+ Documentation/devicetree/bindings/spi/omap-spi.txt |   27 +++++++++++++++++++-
  1 file changed, 26 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/devicetree/bindings/spi/omap-spi.txt b/Documentation/devicetree/bindings/spi/omap-spi.txt
@@ -55,5 +55,5 @@ index 938809c..4c85c4c 100644
 +    dma-names = "tx0", "rx0", "tx1", "rx1";
 +};
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0014-spi-omap2-mcspi-convert-to-dma_request_slave_channel.patch
+++ b/patches/mainline-dma-devel/0014-spi-omap2-mcspi-convert-to-dma_request_slave_channel.patch
@@ -1,4 +1,4 @@
-From 2ecf49d14b2d37abbc67105ea806387926f42f68 Mon Sep 17 00:00:00 2001
+From 4ca63efdb8c19cf219abd32a8f6cabc56439f108 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 20 Sep 2012 00:37:54 -0400
 Subject: [PATCH 14/20] spi: omap2-mcspi: convert to
@@ -15,7 +15,7 @@ Signed-off-by: Matt Porter <mporter@ti.com>
 Acked-by: Mark Brown <broonie@opensource.wolfsonmicro.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- drivers/spi/spi-omap2-mcspi.c | 64 +++++++++++++++++++++++++++++--------------
+ drivers/spi/spi-omap2-mcspi.c |   64 ++++++++++++++++++++++++++++-------------
  1 file changed, 44 insertions(+), 20 deletions(-)
 
 diff --git a/drivers/spi/spi-omap2-mcspi.c b/drivers/spi/spi-omap2-mcspi.c
@@ -117,5 +117,5 @@ index 86d2158..ca4ab78 100644
  
  	if (status < 0)
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0015-ARM-dts-add-AM33XX-EDMA-support.patch
+++ b/patches/mainline-dma-devel/0015-ARM-dts-add-AM33XX-EDMA-support.patch
@@ -1,4 +1,4 @@
-From 4236344ee755e99bbe1da99ce12cf8d1183919ee Mon Sep 17 00:00:00 2001
+From 85592d11aed5306a0516038eddce1d39ab48d9e5 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mdp@ti.com>
 Date: Mon, 27 May 2013 21:52:12 -0500
 Subject: [PATCH 15/20] ARM: dts: add AM33XX EDMA support
@@ -13,7 +13,7 @@ Joel: Drop DT entries that are non-hardware-description for now as discussed in 
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am33xx.dtsi | 12 ++++++++++++
+ arch/arm/boot/dts/am33xx.dtsi |   12 ++++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm/boot/dts/am33xx.dtsi b/arch/arm/boot/dts/am33xx.dtsi
@@ -40,5 +40,5 @@ index 8e1248f..11ae191 100644
  			compatible = "ti,omap4-gpio";
  			ti,hwmods = "gpio1";
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0016-ARM-dts-add-AM33XX-SPI-DMA-support.patch
+++ b/patches/mainline-dma-devel/0016-ARM-dts-add-AM33XX-SPI-DMA-support.patch
@@ -1,4 +1,4 @@
-From eb71cb1b52e11435d7c0b8c2e8aec53f3fb76f8d Mon Sep 17 00:00:00 2001
+From fe9c8308aff18434b99c5160c2ae96395a8c9593 Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 10 Jan 2013 19:09:50 -0500
 Subject: [PATCH 16/20] ARM: dts: add AM33XX SPI DMA support
@@ -8,7 +8,7 @@ Adds DMA resources to the AM33XX SPI nodes.
 Signed-off-by: Matt Porter <mporter@ti.com>
 Signed-off-by: Joel A Fernandes <joelagnel@ti.com>
 ---
- arch/arm/boot/dts/am33xx.dtsi | 10 ++++++++++
+ arch/arm/boot/dts/am33xx.dtsi |   10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/arch/arm/boot/dts/am33xx.dtsi b/arch/arm/boot/dts/am33xx.dtsi
@@ -40,5 +40,5 @@ index 11ae191..21f2b03 100644
  		};
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0017-ARM-dts-add-AM33XX-MMC-support.patch
+++ b/patches/mainline-dma-devel/0017-ARM-dts-add-AM33XX-MMC-support.patch
@@ -1,4 +1,4 @@
-From a8e45fea1d3d084007e5a0ac54049d3732da3716 Mon Sep 17 00:00:00 2001
+From 40042d801d5a4b2f061f329b5e0a5e0011e67fac Mon Sep 17 00:00:00 2001
 From: Matt Porter <mporter@ti.com>
 Date: Thu, 7 Mar 2013 04:16:39 +0000
 Subject: [PATCH 17/20] ARM: dts: add AM33XX MMC support
@@ -18,11 +18,11 @@ Signed-off-by: Matt Porter <mporter@ti.com>
 Acked-by: Tony Lindgren <tony@atomide.com>
 Signed-off-by: Joel Fernandes <joelf@ti.com>
 ---
- .../devicetree/bindings/mmc/ti-omap-hsmmc.txt      | 26 ++++++++++++++-
- arch/arm/boot/dts/am335x-bone.dts                  |  7 ++++
- arch/arm/boot/dts/am335x-evm.dts                   |  7 ++++
- arch/arm/boot/dts/am335x-evmsk.dts                 |  7 ++++
- arch/arm/boot/dts/am33xx.dtsi                      | 38 ++++++++++++++++++++++
+ .../devicetree/bindings/mmc/ti-omap-hsmmc.txt      |   26 +++++++++++++-
+ arch/arm/boot/dts/am335x-bone.dts                  |    7 ++++
+ arch/arm/boot/dts/am335x-evm.dts                   |    7 ++++
+ arch/arm/boot/dts/am335x-evmsk.dts                 |    7 ++++
+ arch/arm/boot/dts/am33xx.dtsi                      |   38 ++++++++++++++++++++
  5 files changed, 84 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/devicetree/bindings/mmc/ti-omap-hsmmc.txt b/Documentation/devicetree/bindings/mmc/ti-omap-hsmmc.txt
@@ -181,5 +181,5 @@ index 21f2b03..916c66a 100644
  			compatible = "ti,omap3-wdt";
  			ti,hwmods = "wd_timer2";
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0018-ARM-configs-Enable-TI_EDMA-in-omap2plus_defconfig.patch
+++ b/patches/mainline-dma-devel/0018-ARM-configs-Enable-TI_EDMA-in-omap2plus_defconfig.patch
@@ -1,4 +1,4 @@
-From f0e39490d35251e9610910bb859be762b5ba1b30 Mon Sep 17 00:00:00 2001
+From 1113381e6b70aa2fd77f978c76280f00d05ffdf5 Mon Sep 17 00:00:00 2001
 From: Joel Fernandes <joelf@ti.com>
 Date: Mon, 24 Jun 2013 09:50:26 -0500
 Subject: [PATCH 18/20] ARM: configs: Enable TI_EDMA in omap2plus_defconfig
@@ -8,7 +8,7 @@ with broken DMA on drivers needing EDMA.
 
 Signed-off-by: Joel Fernandes <joelf@ti.com>
 ---
- arch/arm/configs/omap2plus_defconfig | 1 +
+ arch/arm/configs/omap2plus_defconfig |    1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm/configs/omap2plus_defconfig b/arch/arm/configs/omap2plus_defconfig
@@ -24,5 +24,5 @@ index abbe319..7e00deb 100644
  CONFIG_EXT2_FS=y
  CONFIG_EXT3_FS=y
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0019-DMA-EDMA-Add-comments-for-A-sync-case-calculations.patch
+++ b/patches/mainline-dma-devel/0019-DMA-EDMA-Add-comments-for-A-sync-case-calculations.patch
@@ -1,4 +1,4 @@
-From 29966ba11d1815b63a4eafe0deb9e0f9c0c47662 Mon Sep 17 00:00:00 2001
+From 42f564e9cb41d38cd643cb62656f759f791766a2 Mon Sep 17 00:00:00 2001
 From: Joel Fernandes <joelf@ti.com>
 Date: Tue, 25 Jun 2013 09:35:33 -0500
 Subject: [PATCH 19/20] DMA: EDMA: Add comments for A-sync case calculations
@@ -9,7 +9,7 @@ they are used.
 
 Signed-off-by: Joel Fernandes <joelf@ti.com>
 ---
- drivers/dma/edma.c | 22 ++++++++++++++++++++++
+ drivers/dma/edma.c |   22 ++++++++++++++++++++++
  1 file changed, 22 insertions(+)
 
 diff --git a/drivers/dma/edma.c b/drivers/dma/edma.c
@@ -55,5 +55,5 @@ index e008ed2..a1d9f3785 100644
  
  	}
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dma-devel/0020-am33xx-edma-Always-update-unused-channel-list.patch
+++ b/patches/mainline-dma-devel/0020-am33xx-edma-Always-update-unused-channel-list.patch
@@ -1,4 +1,4 @@
-From b146864a185f599048910208faf64029e7ec736c Mon Sep 17 00:00:00 2001
+From 77d5449636790fa916af75703bea6aadb16ebd76 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 15 Jan 2013 20:03:18 +0200
 Subject: [PATCH 20/20] am33xx: edma: Always update unused channel list
@@ -8,7 +8,7 @@ of the the unused channels list is wrong, so do it every time.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/common/edma.c | 27 ++++++++++++---------------
+ arch/arm/common/edma.c |   27 ++++++++++++---------------
  1 file changed, 12 insertions(+), 15 deletions(-)
 
 diff --git a/arch/arm/common/edma.c b/arch/arm/common/edma.c
@@ -57,5 +57,5 @@ index 3567ba1..62808d3 100644
  	if (channel >= 0) {
  		ctlr = EDMA_CTLR(channel);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dtc-fixes/0001-Fix-util_is_printable_string.patch
+++ b/patches/mainline-dtc-fixes/0001-Fix-util_is_printable_string.patch
@@ -1,4 +1,4 @@
-From b063a0fbad6a482605061c42f52b8a838dbc3a26 Mon Sep 17 00:00:00 2001
+From 105dae5f8fe80a4a6471cb71e2f76aa6477a1315 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 6 Dec 2012 13:22:49 +0200
 Subject: [PATCH 1/2] Fix util_is_printable_string
@@ -7,7 +7,7 @@ The method used did not account for multi-part strings.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- scripts/dtc/util.c | 20 +++++++++++++-------
+ scripts/dtc/util.c |   20 +++++++++++++-------
  1 file changed, 13 insertions(+), 7 deletions(-)
 
 diff --git a/scripts/dtc/util.c b/scripts/dtc/util.c
@@ -50,5 +50,5 @@ index 2422c34..45f186b 100644
  	return 1;
  }
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dtc-fixes/0002-fdtdump-properly-handle-multi-string-properties.patch
+++ b/patches/mainline-dtc-fixes/0002-fdtdump-properly-handle-multi-string-properties.patch
@@ -1,4 +1,4 @@
-From a0c807e6c36ac347bd13a39f2d0b69bac71bf8ef Mon Sep 17 00:00:00 2001
+From d611dbc2d8dcc14ffdbbf475c5ce8c6596473380 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 6 Dec 2012 13:44:10 +0200
 Subject: [PATCH 2/2] fdtdump: properly handle multi-string properties
@@ -8,7 +8,7 @@ We didn't handle that case properly.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- scripts/dtc/fdtdump.c | 12 +++++++++++-
+ scripts/dtc/fdtdump.c |   12 +++++++++++-
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/dtc/fdtdump.c b/scripts/dtc/fdtdump.c
@@ -41,5 +41,5 @@ index 207a46d..d4fa6d7 100644
  		printf(" = <");
  		for (i = 0; i < len; i += 4)
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dtc-overlays/0001-dtc-Dynamic-symbols-fixup-support.patch
+++ b/patches/mainline-dtc-overlays/0001-dtc-Dynamic-symbols-fixup-support.patch
@@ -1,4 +1,4 @@
-From 7888461dfe2750bbb0bfc3eab14c0e0e21e417e8 Mon Sep 17 00:00:00 2001
+From d97de3be2beeeea0492646c3f4f86a420ef8c12f Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 6 Dec 2012 13:48:11 +0200
 Subject: [PATCH 1/2] dtc: Dynamic symbols & fixup support
@@ -17,14 +17,14 @@ This is sufficient to implement a dynamic DT object loader.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- Documentation/devicetree/00-INDEX               |   1 +
- Documentation/devicetree/dt-object-internal.txt | 295 ++++++++++++++++++++++++
- scripts/dtc/checks.c                            | 120 +++++++++-
- scripts/dtc/dtc-lexer.l                         |   5 +
- scripts/dtc/dtc-parser.y                        |  23 +-
- scripts/dtc/dtc.c                               |   9 +-
- scripts/dtc/dtc.h                               |  38 +++
- scripts/dtc/flattree.c                          | 139 +++++++++++
+ Documentation/devicetree/00-INDEX               |    1 +
+ Documentation/devicetree/dt-object-internal.txt |  295 +++++++++++++++++++++++
+ scripts/dtc/checks.c                            |  120 ++++++++-
+ scripts/dtc/dtc-lexer.l                         |    5 +
+ scripts/dtc/dtc-parser.y                        |   23 +-
+ scripts/dtc/dtc.c                               |    9 +-
+ scripts/dtc/dtc.h                               |   38 +++
+ scripts/dtc/flattree.c                          |  139 +++++++++++
  8 files changed, 621 insertions(+), 9 deletions(-)
  create mode 100644 Documentation/devicetree/dt-object-internal.txt
 
@@ -839,5 +839,5 @@ index 665dad7..5b2e75e 100644
  }
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dtc-overlays/0002-dtc-Dynamic-symbols-fixup-support-shipped.patch
+++ b/patches/mainline-dtc-overlays/0002-dtc-Dynamic-symbols-fixup-support-shipped.patch
@@ -1,4 +1,4 @@
-From 6af6b6fcb4968a9b45517a5578dd5b72b079c922 Mon Sep 17 00:00:00 2001
+From 23fd439ed897bf6291390482ef1fb59084fb517f Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Wed, 26 Jun 2013 15:13:52 +0300
 Subject: [PATCH 2/2] dtc: Dynamic symbols & fixup support (shipped)
@@ -2853,5 +2853,5 @@ index 25d3b88..e4dfadf 100644
  # define YYSTYPE_IS_TRIVIAL 1
  # define yystype YYSTYPE /* obsolescent; will be withdrawn */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dts-fixes/0001-am335x-dts-Add-beaglebone-black-DTS.patch
+++ b/patches/mainline-dts-fixes/0001-am335x-dts-Add-beaglebone-black-DTS.patch
@@ -1,4 +1,4 @@
-From 3ca19144b45a915544fb61ec907c8b75519af8be Mon Sep 17 00:00:00 2001
+From 7843a0df70f983c52a8371a6ac1a254743007bb6 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Jun 2013 14:18:08 +0300
 Subject: [PATCH 1/3] am335x: dts: Add beaglebone black DTS
@@ -8,8 +8,8 @@ time we'll switch to using a common black.dtsi file.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/boot/dts/Makefile             |   3 +-
- arch/arm/boot/dts/am335x-boneblack.dts | 196 +++++++++++++++++++++++++++++++++
+ arch/arm/boot/dts/Makefile             |    3 +-
+ arch/arm/boot/dts/am335x-boneblack.dts |  196 ++++++++++++++++++++++++++++++++
  2 files changed, 198 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/boot/dts/am335x-boneblack.dts
 
@@ -230,5 +230,5 @@ index 0000000..d21e223
 +	reset-gpio = <&gpio1 20 0x00>;
 +};
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dts-fixes/0002-dts-beaglebone-Add-I2C-definitions-for-EEPROMs-capes.patch
+++ b/patches/mainline-dts-fixes/0002-dts-beaglebone-Add-I2C-definitions-for-EEPROMs-capes.patch
@@ -1,4 +1,4 @@
-From 4bbaef1c2cf5888a181e8c223849de89aa3b4141 Mon Sep 17 00:00:00 2001
+From f10ad8b1b280b23269386bdef6057f02a8d02ce9 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Jun 2013 18:39:55 +0300
 Subject: [PATCH 2/3] dts: beaglebone: Add I2C definitions for EEPROMs & capes
@@ -8,8 +8,8 @@ and on the possibly connected capes.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/boot/dts/am335x-bone.dts      | 46 ++++++++++++++++++++++++++++++++++
- arch/arm/boot/dts/am335x-boneblack.dts | 46 ++++++++++++++++++++++++++++++++++
+ arch/arm/boot/dts/am335x-bone.dts      |   46 ++++++++++++++++++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   46 ++++++++++++++++++++++++++++++++
  2 files changed, 92 insertions(+)
 
 diff --git a/arch/arm/boot/dts/am335x-bone.dts b/arch/arm/boot/dts/am335x-bone.dts
@@ -156,5 +156,5 @@ index d21e223..4d464f6 100644
  	};
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-dts-fixes/0003-arm-beaglebone-dts-Add-capemanager-to-the-DTS.patch
+++ b/patches/mainline-dts-fixes/0003-arm-beaglebone-dts-Add-capemanager-to-the-DTS.patch
@@ -1,4 +1,4 @@
-From 396584e037afc8c007a285d9bb04818a6e1197ba Mon Sep 17 00:00:00 2001
+From 972a14bac3e7c10670f7f832090c33a01c6171d7 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Jun 2013 18:52:33 +0300
 Subject: [PATCH 3/3] arm: beaglebone: dts: Add capemanager to the DTS
@@ -7,8 +7,8 @@ Add the capemanager in the bone/beaglebone DTS.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/boot/dts/am335x-bone.dts      | 75 ++++++++++++++++++++++++++++++++++
- arch/arm/boot/dts/am335x-boneblack.dts | 74 +++++++++++++++++++++++++++++++++
+ arch/arm/boot/dts/am335x-bone.dts      |   75 ++++++++++++++++++++++++++++++++
+ arch/arm/boot/dts/am335x-boneblack.dts |   74 +++++++++++++++++++++++++++++++
  2 files changed, 149 insertions(+)
 
 diff --git a/arch/arm/boot/dts/am335x-bone.dts b/arch/arm/boot/dts/am335x-bone.dts
@@ -183,5 +183,5 @@ index 4d464f6..c27b845 100644
  
  /include/ "tps65217.dtsi"
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-fixes/0001-add-PM-firmware.patch
+++ b/patches/mainline-fixes/0001-add-PM-firmware.patch
@@ -1,11 +1,11 @@
-From 804ba3d95bf03d61409b89dee1cb3ef433ba4506 Mon Sep 17 00:00:00 2001
+From cb8aab0f19ed3b45438ef04b8fd85b5140700975 Mon Sep 17 00:00:00 2001
 From: Koen Kooi <koen@dominion.thruhere.net>
 Date: Thu, 6 Jun 2013 17:09:38 +0200
 Subject: [PATCH 1/3] add PM firmware
 
 Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
 ---
- firmware/am335x-pm-firmware.bin | Bin 0 -> 10964 bytes
+ firmware/am335x-pm-firmware.bin |  Bin 0 -> 10964 bytes
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 firmware/am335x-pm-firmware.bin
 
@@ -100,5 +100,5 @@ literal 0
 HcmV?d00001
 
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-fixes/0002-ARM-CUSTOM-Build-a-uImage-with-dtb-already-appended.patch
+++ b/patches/mainline-fixes/0002-ARM-CUSTOM-Build-a-uImage-with-dtb-already-appended.patch
@@ -1,4 +1,4 @@
-From 8f67d2cf23cc982c242255a3104195b57a14204d Mon Sep 17 00:00:00 2001
+From 36389ca3473e99977faf4f0742f09ab8ff0912cd Mon Sep 17 00:00:00 2001
 From: Grant Likely <grant.likely@secretlab.ca>
 Date: Tue, 2 Aug 2011 15:30:09 +0100
 Subject: [PATCH 2/3] ARM: CUSTOM: Build a uImage with dtb already appended
@@ -12,8 +12,8 @@ Conflicts:
 
 	arch/arm/Makefile
 ---
- arch/arm/Makefile      | 3 +++
- arch/arm/boot/Makefile | 7 +++++++
+ arch/arm/Makefile      |    3 +++
+ arch/arm/boot/Makefile |    7 +++++++
  2 files changed, 10 insertions(+)
 
 diff --git a/arch/arm/Makefile b/arch/arm/Makefile
@@ -56,5 +56,5 @@ index 84aa2ca..7b03519 100644
  	$(Q)$(MAKE) $(build)=$(obj)/bootp $@
  	@:
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-fixes/0003-Thumb-2-Add-local-symbols-to-work-around-gas-behavio.patch
+++ b/patches/mainline-fixes/0003-Thumb-2-Add-local-symbols-to-work-around-gas-behavio.patch
@@ -1,4 +1,4 @@
-From 41c5210129f56d9812b9729162f89b7dfbce6008 Mon Sep 17 00:00:00 2001
+From 58380022b502ada296580a83b4aa0353fdd19a2a Mon Sep 17 00:00:00 2001
 From: Dave Martin <(address hidden)>
 Date: Wed, 21 Nov 2012 19:11:52 +0100
 Subject: [PATCH 3/3] Thumb-2: Add local symbols to work around gas behaviour
@@ -38,7 +38,7 @@ Similar fixes may be needed in mach-specific assembler.
 Signed-off-by: Dave Martin <(address hidden)>
 Acked-by: Nicolas Pitre <(address hidden)>
 ---
- arch/arm/kernel/relocate_kernel.S | 12 ++++++++----
+ arch/arm/kernel/relocate_kernel.S |   12 ++++++++----
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/kernel/relocate_kernel.S b/arch/arm/kernel/relocate_kernel.S
@@ -92,5 +92,5 @@ index d0cdedf..fe57bb9 100644
  
  relocate_new_kernel_end:
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-i2c-fixes/0001-i2c-EEPROM-In-kernel-memory-accessor-interface.patch
+++ b/patches/mainline-i2c-fixes/0001-i2c-EEPROM-In-kernel-memory-accessor-interface.patch
@@ -1,4 +1,4 @@
-From 70d2d4c9b305488fff45bf61b3cab4cc0a13a6fe Mon Sep 17 00:00:00 2001
+From 091b4b609c0320704aee99374b6e6833b96ce0ec Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 13 Dec 2012 11:23:21 +0200
 Subject: [PATCH 1/2] i2c-EEPROM: In kernel memory accessor interface
@@ -8,8 +8,8 @@ interface. Extend at24 to use it via the command interface.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/eeprom/at24.c | 23 ++++++++++++++++++
- include/linux/i2c/eeprom.h | 59 ++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/misc/eeprom/at24.c |   23 +++++++++++++++++
+ include/linux/i2c/eeprom.h |   59 ++++++++++++++++++++++++++++++++++++++++++++
  2 files changed, 82 insertions(+)
  create mode 100644 include/linux/i2c/eeprom.h
 
@@ -127,5 +127,5 @@ index 0000000..1393980
 +
 +#endif
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-i2c-fixes/0002-grove-i2c-Add-rudimentary-grove-i2c-motor-control-dr.patch
+++ b/patches/mainline-i2c-fixes/0002-grove-i2c-Add-rudimentary-grove-i2c-motor-control-dr.patch
@@ -1,4 +1,4 @@
-From 45d4370ecf178142e9df580deaae55f294af149f Mon Sep 17 00:00:00 2001
+From bdacdd20f5d1e55a215a54f9a30ffcea703ea603 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 5 Mar 2013 19:45:36 +0200
 Subject: [PATCH 2/2] grove-i2c: Add rudimentary grove i2c motor control
@@ -8,9 +8,9 @@ Simple solenoid handling using grove i2c.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/misc/Kconfig     |   6 ++
- drivers/misc/Makefile    |   1 +
- drivers/misc/grove-i2c.c | 239 +++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/misc/Kconfig     |    6 ++
+ drivers/misc/Makefile    |    1 +
+ drivers/misc/grove-i2c.c |  239 ++++++++++++++++++++++++++++++++++++++++++++++
  3 files changed, 246 insertions(+)
  create mode 100644 drivers/misc/grove-i2c.c
 
@@ -286,5 +286,5 @@ index 0000000..8932616
 +MODULE_DESCRIPTION("Grove I2C Motor control driver");
 +MODULE_LICENSE("GPL");
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-mmc-fixes/0001-omap-hsmmc-Correct-usage-of-of_find_node_by_name.patch
+++ b/patches/mainline-mmc-fixes/0001-omap-hsmmc-Correct-usage-of-of_find_node_by_name.patch
@@ -1,11 +1,11 @@
-From 94ba134c464aaf9274f8e8d0b7bc6e689b368dd8 Mon Sep 17 00:00:00 2001
+From 11f4a553784f323626dd25a584ffddf44b02f690 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 26 Oct 2012 15:48:00 +0300
 Subject: [PATCH 1/2] omap-hsmmc: Correct usage of of_find_node_by_name
 
 of_find_node_by_name expect to have the parent node reference taken.
 ---
- drivers/mmc/host/omap_hsmmc.c | 10 ++++++++++
+ drivers/mmc/host/omap_hsmmc.c |   10 ++++++++++
  1 file changed, 10 insertions(+)
 
 diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
@@ -30,5 +30,5 @@ index efe9cc9..454b325 100644
  	mmc->max_blk_count = 0xFFFF;    /* No. of Blocks is 16 bits */
  	mmc->max_req_size = mmc->max_blk_size * mmc->max_blk_count;
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-mmc-fixes/0002-omap_hsmmc-Add-reset-gpio.patch
+++ b/patches/mainline-mmc-fixes/0002-omap_hsmmc-Add-reset-gpio.patch
@@ -1,4 +1,4 @@
-From 35134aadd76e4d2d1902b5f791ce9cd0fd96dacf Mon Sep 17 00:00:00 2001
+From efa53022262f45a1782571df1d2f2b387fae8ff6 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 30 Nov 2012 12:18:16 +0200
 Subject: [PATCH 2/2] omap_hsmmc: Add reset gpio
@@ -8,8 +8,8 @@ eMMC on the beaglebone black requires it.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/mmc/host/omap_hsmmc.c          | 40 +++++++++++++++++++++++++++++++++-
- include/linux/platform_data/mmc-omap.h |  3 +++
+ drivers/mmc/host/omap_hsmmc.c          |   40 +++++++++++++++++++++++++++++++-
+ include/linux/platform_data/mmc-omap.h |    3 +++
  2 files changed, 42 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
@@ -134,5 +134,5 @@ index 2bf1b30..d548994 100644
  		int (*set_bus_mode)(struct device *dev, int slot, int bus_mode);
  		int (*set_power)(struct device *dev, int slot,
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0001-of-i2c-Export-single-device-registration-method.patch
+++ b/patches/mainline-of-fixes/0001-of-i2c-Export-single-device-registration-method.patch
@@ -1,4 +1,4 @@
-From 51e145a74fc886ddf0cae65e53fe1fbca2e926cb Mon Sep 17 00:00:00 2001
+From e1e653efc78024ccaa4eacfa2574c1f4e0fc01f4 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 15 Jan 2013 11:26:27 +0200
 Subject: [PATCH 1/8] of: i2c: Export single device registration method
@@ -8,8 +8,8 @@ of a single device registration method. Rework and export it.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/of_i2c.c    | 104 +++++++++++++++++++++++++++----------------------
- include/linux/of_i2c.h |  11 ++++++
+ drivers/of/of_i2c.c    |  104 ++++++++++++++++++++++++++----------------------
+ include/linux/of_i2c.h |   11 +++++
  2 files changed, 68 insertions(+), 47 deletions(-)
 
 diff --git a/drivers/of/of_i2c.c b/drivers/of/of_i2c.c
@@ -167,5 +167,5 @@ index cfb545c..53fca8f 100644
  {
  	return;
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0002-OF-Clear-detach-flag-on-attach.patch
+++ b/patches/mainline-of-fixes/0002-OF-Clear-detach-flag-on-attach.patch
@@ -1,4 +1,4 @@
-From 6bb8897df4e3a36445c9e8f5078b5157e8a41c71 Mon Sep 17 00:00:00 2001
+From 7c4dd7503048ba445109da9214a18b984b4b2395 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Wed, 27 Feb 2013 11:26:34 +0200
 Subject: [PATCH 2/8] OF: Clear detach flag on attach
@@ -8,7 +8,7 @@ the sequence detach, attach fails.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/base.c | 1 +
+ drivers/of/base.c |    1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/of/base.c b/drivers/of/base.c
@@ -24,5 +24,5 @@ index a6f584a..623d47e 100644
  
  	of_add_proc_dt_entry(np);
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0003-OF-Introduce-device-tree-node-flag-helpers.patch
+++ b/patches/mainline-of-fixes/0003-OF-Introduce-device-tree-node-flag-helpers.patch
@@ -1,4 +1,4 @@
-From bbfbf69db684ca11018cc58c4cd6253eacce2f9d Mon Sep 17 00:00:00 2001
+From 9fc1abb3922b081371a9ece9d099e0113ba32f87 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 14 Dec 2012 13:10:51 +0200
 Subject: [PATCH 3/8] OF: Introduce device tree node flag helpers.
@@ -7,7 +7,7 @@ Helper functions for working with device node flags.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- include/linux/of.h | 20 ++++++++++++++++++++
+ include/linux/of.h |   20 ++++++++++++++++++++
  1 file changed, 20 insertions(+)
 
 diff --git a/include/linux/of.h b/include/linux/of.h
@@ -42,5 +42,5 @@ index 1fd08ca..32ad0b0 100644
  
  /*
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0004-OF-export-of_property_notify.patch
+++ b/patches/mainline-of-fixes/0004-OF-export-of_property_notify.patch
@@ -1,4 +1,4 @@
-From 7cd90f5a8899aa3b94113b9aa732d73766accf28 Mon Sep 17 00:00:00 2001
+From de7bb79013ece8c1bb40a7a91220c30f549b1e8d Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 3 Jan 2013 11:46:39 +0200
 Subject: [PATCH 4/8] OF: export of_property_notify
@@ -7,8 +7,8 @@ of_property_notify can be utilized by other users too, export it.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/base.c  |  8 +-------
- include/linux/of.h | 11 +++++++++++
+ drivers/of/base.c  |    8 +-------
+ include/linux/of.h |   11 +++++++++++
  2 files changed, 12 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/of/base.c b/drivers/of/base.c
@@ -60,5 +60,5 @@ index 32ad0b0..9c159e6 100644
  extern int of_alias_get_id(struct device_node *np, const char *stem);
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0005-OF-Export-all-DT-proc-update-functions.patch
+++ b/patches/mainline-of-fixes/0005-OF-Export-all-DT-proc-update-functions.patch
@@ -1,4 +1,4 @@
-From 1a10eb53d0caa7d7bcfd0068de8a2d206ec35c24 Mon Sep 17 00:00:00 2001
+From 182eb4a3ec30e985c63c8476b8de5a4851bd9380 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 3 Jan 2013 12:02:14 +0200
 Subject: [PATCH 5/8] OF: Export all DT proc update functions
@@ -8,8 +8,8 @@ Export them.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/base.c  | 70 ++++++++++++++++++++++++++++++------------------------
- include/linux/of.h | 29 ++++++++++++++++++++++
+ drivers/of/base.c  |   70 +++++++++++++++++++++++++++++-----------------------
+ include/linux/of.h |   29 ++++++++++++++++++++++
  2 files changed, 68 insertions(+), 31 deletions(-)
 
 diff --git a/drivers/of/base.c b/drivers/of/base.c
@@ -175,5 +175,5 @@ index 9c159e6..c7a6d8b 100644
  extern int of_alias_get_id(struct device_node *np, const char *stem);
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0006-OF-Introduce-utility-helper-functions.patch
+++ b/patches/mainline-of-fixes/0006-OF-Introduce-utility-helper-functions.patch
@@ -1,4 +1,4 @@
-From bb98b6d7e3b86ca9fe66dd4ee613afbe3884fc97 Mon Sep 17 00:00:00 2001
+From 1c6f5dd55ea05402d55ac99f558e9c3f16b91132 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 3 Jan 2013 12:11:31 +0200
 Subject: [PATCH 6/8] OF: Introduce utility helper functions
@@ -16,9 +16,9 @@ having to take locks.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/Makefile |   2 +-
- drivers/of/util.c   | 253 ++++++++++++++++++++++++++++++++++++++++++++++++++++
- include/linux/of.h  |  59 ++++++++++++
+ drivers/of/Makefile |    2 +-
+ drivers/of/util.c   |  253 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ include/linux/of.h  |   59 ++++++++++++
  3 files changed, 313 insertions(+), 1 deletion(-)
  create mode 100644 drivers/of/util.c
 
@@ -360,5 +360,5 @@ index c7a6d8b..8c2ee71 100644
 +
  #endif /* _LINUX_OF_H */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0007-OF-Introduce-Device-Tree-resolve-support.patch
+++ b/patches/mainline-of-fixes/0007-OF-Introduce-Device-Tree-resolve-support.patch
@@ -1,4 +1,4 @@
-From c42a31425d6c8df42011f78ab29587407fbb55e9 Mon Sep 17 00:00:00 2001
+From eecb2216793fb65849b3a9745c7747ba80914f9d Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 3 Jan 2013 12:18:25 +0200
 Subject: [PATCH 7/8] OF: Introduce Device Tree resolve support.
@@ -10,11 +10,11 @@ live tree.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- .../devicetree/dynamic-resolution-notes.txt        |  25 ++
- drivers/of/Kconfig                                 |   9 +
- drivers/of/Makefile                                |   1 +
- drivers/of/resolver.c                              | 395 +++++++++++++++++++++
- include/linux/of.h                                 |  17 +
+ .../devicetree/dynamic-resolution-notes.txt        |   25 ++
+ drivers/of/Kconfig                                 |    9 +
+ drivers/of/Makefile                                |    1 +
+ drivers/of/resolver.c                              |  395 ++++++++++++++++++++
+ include/linux/of.h                                 |   17 +
  5 files changed, 447 insertions(+)
  create mode 100644 Documentation/devicetree/dynamic-resolution-notes.txt
  create mode 100644 drivers/of/resolver.c
@@ -505,5 +505,5 @@ index 8c2ee71..6ed844d 100644
 +
  #endif /* _LINUX_OF_H */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-of-fixes/0008-OF-Introduce-DT-overlay-support.patch
+++ b/patches/mainline-of-fixes/0008-OF-Introduce-DT-overlay-support.patch
@@ -1,4 +1,4 @@
-From e4d3903b5cc1e25347b1aa7f55ee5da720e1b3c3 Mon Sep 17 00:00:00 2001
+From 4745b45c71944d0415fb62badd790dc8ffbbb3e1 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Thu, 3 Jan 2013 12:23:07 +0200
 Subject: [PATCH 8/8] OF: Introduce DT overlay support.
@@ -16,11 +16,11 @@ special casing.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- Documentation/devicetree/overlay-notes.txt | 179 ++++++
- drivers/of/Kconfig                         |  10 +
- drivers/of/Makefile                        |   1 +
- drivers/of/overlay.c                       | 870 +++++++++++++++++++++++++++++
- include/linux/of.h                         | 113 ++++
+ Documentation/devicetree/overlay-notes.txt |  179 ++++++
+ drivers/of/Kconfig                         |   10 +
+ drivers/of/Makefile                        |    1 +
+ drivers/of/overlay.c                       |  870 ++++++++++++++++++++++++++++
+ include/linux/of.h                         |  113 ++++
  5 files changed, 1173 insertions(+)
  create mode 100644 Documentation/devicetree/overlay-notes.txt
  create mode 100644 drivers/of/overlay.c
@@ -1244,5 +1244,5 @@ index 6ed844d..7b3e332 100644
 +
  #endif /* _LINUX_OF_H */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-pdev-fixes/0001-pdev-Fix-platform-device-resource-linking.patch
+++ b/patches/mainline-pdev-fixes/0001-pdev-Fix-platform-device-resource-linking.patch
@@ -1,4 +1,4 @@
-From 0a685a0a4821ead07529b4fa94e01c0bc00e518e Mon Sep 17 00:00:00 2001
+From 7f949a82efe67a3c09486b4bd724e375da63f2a7 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Dec 2012 11:34:15 +0200
 Subject: [PATCH 1/4] pdev: Fix platform device resource linking
@@ -21,8 +21,8 @@ resources.
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/base/platform.c         | 122 +++++++++++++++++++++++++++-------------
- include/linux/platform_device.h |   4 ++
+ drivers/base/platform.c         |  122 ++++++++++++++++++++++++++-------------
+ include/linux/platform_device.h |    4 ++
  2 files changed, 87 insertions(+), 39 deletions(-)
 
 diff --git a/drivers/base/platform.c b/drivers/base/platform.c
@@ -212,5 +212,5 @@ index 9abf1db..eb9e34a 100644
 +
  #endif /* _PLATFORM_DEVICE_H_ */
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-pdev-fixes/0002-of-Link-platform-device-resources-properly.patch
+++ b/patches/mainline-pdev-fixes/0002-of-Link-platform-device-resources-properly.patch
@@ -1,4 +1,4 @@
-From bf3d7a542e4c14c8623ecd815b090c581cfbb68f Mon Sep 17 00:00:00 2001
+From 32b8874f3a71704770f360bccf83b4f4547e727f Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Dec 2012 11:39:29 +0200
 Subject: [PATCH 2/4] of: Link platform device resources properly.
@@ -12,7 +12,7 @@ This commit is based on the previous commit of
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- drivers/of/device.c | 3 +++
+ drivers/of/device.c |    3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/of/device.c b/drivers/of/device.c
@@ -30,5 +30,5 @@ index f685e55..b4b95c6 100644
  }
  
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-pdev-fixes/0003-omap-Properly-handle-resources-for-omap_devices.patch
+++ b/patches/mainline-pdev-fixes/0003-omap-Properly-handle-resources-for-omap_devices.patch
@@ -1,4 +1,4 @@
-From 0f73fa7fbab98bc4efe0c8e5c1522d5c72030a8e Mon Sep 17 00:00:00 2001
+From 0c4d516b25b86a9ea9e547c0f30d169d9b57dbcc Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Fri, 28 Dec 2012 11:41:11 +0200
 Subject: [PATCH 3/4] omap: Properly handle resources for omap_devices
@@ -13,7 +13,7 @@ and make sure that no resources that have no parent (which can happen for DMA
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/mach-omap2/omap_device.c | 232 ++++++++++++++++++++++++--------------
+ arch/arm/mach-omap2/omap_device.c |  232 +++++++++++++++++++++++--------------
  1 file changed, 148 insertions(+), 84 deletions(-)
 
 diff --git a/arch/arm/mach-omap2/omap_device.c b/arch/arm/mach-omap2/omap_device.c
@@ -290,5 +290,5 @@ index e6d2307..29d3d7b 100644
  
  	for (i = 0; i < oh_cnt; i++) {
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-pdev-fixes/0004-omap-Avoid-crashes-in-the-case-of-hwmod-misconfigura.patch
+++ b/patches/mainline-pdev-fixes/0004-omap-Avoid-crashes-in-the-case-of-hwmod-misconfigura.patch
@@ -1,7 +1,8 @@
-From 3843d7b377f3217674c522bf0e942c02f9b77e3f Mon Sep 17 00:00:00 2001
+From 5a3d4598e9077f3ab39e8da0720877ff474ab744 Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Tue, 8 Jan 2013 15:19:52 +0200
-Subject: [PATCH 4/4] omap: Avoid crashes in the case of hwmod misconfiguration
+Subject: [PATCH 4/4] omap: Avoid crashes in the case of hwmod
+ misconfiguration
 
 omap hwmod is really sensitive to hwmod misconfiguration.
 Getting a minor clock wrong always ended up in a crash.
@@ -49,7 +50,7 @@ Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b!
 
 Signed-off-by: Pantelis Antoniou <panto@antoniou-consulting.com>
 ---
- arch/arm/mach-omap2/omap_hwmod.c | 8 ++++++--
+ arch/arm/mach-omap2/omap_hwmod.c |    8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm/mach-omap2/omap_hwmod.c b/arch/arm/mach-omap2/omap_hwmod.c
@@ -79,5 +80,5 @@ index 7341eff..42cb7d4 100644
  		oc->_clk = c;
  		/*
 -- 
-1.8.2.1
+1.7.9.5
 

--- a/patches/mainline-pinctrl-fixes/0001-pinctrl-pinctrl-single-must-be-initialized-early.patch
+++ b/patches/mainline-pinctrl-fixes/0001-pinctrl-pinctrl-single-must-be-initialized-early.patch
@@ -1,4 +1,4 @@
-From bf3fcd64e46f9f079fc5dc8b6a20e03cfc16321d Mon Sep 17 00:00:00 2001
+From ee55ee82156a5e5c81fd1f65a8a494dcab93d23a Mon Sep 17 00:00:00 2001
 From: Pantelis Antoniou <panto@antoniou-consulting.com>
 Date: Sat, 15 Sep 2012 12:00:41 +0300
 Subject: [PATCH] pinctrl: pinctrl-single must be initialized early.
@@ -7,7 +7,7 @@ When using pinctrl-single to handle i2c initialization, it has
 to be done early. Whether this is the best way to do so, is an
 exercise left to the reader.
 ---
- drivers/pinctrl/pinctrl-single.c | 12 +++++++++++-
+ drivers/pinctrl/pinctrl-single.c |   12 +++++++++++-
  1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/pinctrl/pinctrl-single.c b/drivers/pinctrl/pinctrl-single.c
@@ -34,5 +34,5 @@ index b9fa046..17f7bb5 100644
  MODULE_AUTHOR("Tony Lindgren <tony@atomide.com>");
  MODULE_DESCRIPTION("One-register-per-pin type device tree based pinctrl driver");
 -- 
-1.8.2.1
+1.7.9.5
 


### PR DESCRIPTION
Update. I've updated my repo too. It should merge. And I added some checkpatch.pl fixes as well.

This adds a bunch of patches to the adc patchset enabling continous
sampling mode. A large buffer of data can now be read via /dev/iio entries

The work is forward ported from the Arago tree.
The original author is Rachil Patna.

Some of his patches might seem missing from Arago but that is because

1) I incorporated _some_ of his minor bugfixes in the same large main patch.
2) Some of the patches have already been incorporated in the patchset in mfd-next.

The rest of the small bug fixes by Russ Dill are kept in separate patches.

All in all. This brings all the functionality of the ADC driver in the Arago tree
to the BBB.

evtest for touchscreen does register events too
