### PR TITLE
Adds continuous sampling patch files only

### DIFF
--- a/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
+++ b/patches/adc/0005-input-ti_tsc-Enable-shared-IRQ-for-TSC.patch
@@ -1,0 +1,66 @@
+From 3122340ff57f28de5c4ea12545a245f8b6a3a669 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 19:36:34 +0100
+Subject: [PATCH 05/22] input: ti_tsc: Enable shared IRQ for TSC
+
+Touchscreen and ADC share the same IRQ line from parent
+
+MFD core.
+
+Previously only Touchscreen was interrupt based.
+
+With continuous mode support added in ADC driver, now driver requires
+
+interrupt to process the ADC samples, so enable shared IRQ flag bit for
+
+touchscreen.
+
+Forward ported from Arago tree
+---
+ drivers/input/touchscreen/ti_am335x_tsc.c |   16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index 0e9f02a..cf56cae 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -260,8 +260,16 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	unsigned int fsm;
+ 
+ 	status = titsc_readl(ts_dev, REG_IRQSTATUS);
+-	if (status & IRQENB_FIFO0THRES) {
+-
++ 
++        /*
++         * ADC and touchscreen share the IRQ line.
++         * FIFO1 threshold interrupt is used by ADC,
++         * hence return from touchscreen IRQ handler if FIFO1
++         * threshold interrupt occurred.
++         */
++        if (status & IRQENB_FIFO1THRES)
++                return IRQ_NONE;
++        else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+ 
+ 		if (ts_dev->pen_down && z1 != 0 && z2 != 0) {
+@@ -315,7 +323,7 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	}
+ 
+ 	if (irqclr) {
+-		titsc_writel(ts_dev, REG_IRQSTATUS, irqclr);
++		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr) );
+ 		am335x_tsc_se_update(ts_dev->mfd_tscadc);
+ 		return IRQ_HANDLED;
+ 	}
+@@ -389,7 +397,7 @@ static int titsc_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	err = request_irq(ts_dev->irq, titsc_irq,
+-			  0, pdev->dev.driver->name, ts_dev);
++			  IRQF_SHARED, pdev->dev.driver->name, ts_dev);
+ 	if (err) {
+ 		dev_err(&pdev->dev, "failed to allocate irq.\n");
+ 		goto err_free_mem;
+-- 
+1.7.9.5
+

--- a/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
+++ b/patches/adc/0006-iio-input-am335x_adc-Add-continuous-mode-to-adc.patch
@@ -1,0 +1,612 @@
+From b47a28f230cddeb717abb9f838e1d0f6bdddd497 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 21:45:58 +0100
+Subject: [PATCH 06/22] iio: input: am335x_adc: Add continuous mode to adc
+
+This is a rather large patch. Which adds a rather large feature.
+The ADC supports continuous sampling. This is added to the driver.
+The IRQs are changed in the TSC drivers as they are shared with
+the ADC IRQ lines.
+
+Forward ported from Arago tree based on 3.2
+---
+ drivers/iio/adc/ti_am335x_adc.c           |  386 ++++++++++++++++++++++++-----
+ drivers/input/touchscreen/ti_am335x_tsc.c |    9 +-
+ drivers/mfd/ti_am335x_tscadc.c            |   12 +-
+ include/linux/mfd/ti_am335x_tscadc.h      |   12 +
+ 4 files changed, 351 insertions(+), 68 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 8a63203..1f6e800 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -29,11 +29,25 @@
+ #include <linux/math64.h>
+ #include <linux/mfd/ti_am335x_tscadc.h>
+ 
++#include <linux/stat.h>
++
++#include <linux/sched.h>
++#include <linux/iio/buffer.h>
++#include <linux/iio/trigger_consumer.h>
++#include <linux/iio/kfifo_buf.h>
++#include <linux/iio/sysfs.h>
++#include <linux/delay.h>
++
+ struct tiadc_device {
+ 	struct ti_tscadc_dev *mfd_tscadc;
+ 	int channels;
+ 	u8 channel_line[8];
+ 	u8 channel_step[8];
++	struct work_struct      poll_work;
++	wait_queue_head_t       wq_data_avail;
++	int                     irq;
++	bool                    is_continuous_mode;
++        u16                     *buffer;
+ };
+ 
+ static unsigned int tiadc_readl(struct tiadc_device *adc, unsigned int reg)
+@@ -56,7 +70,7 @@ static u32 get_adc_step_mask(struct tiadc_device *adc_dev)
+ 	return step_en;
+ }
+ 
+-static void tiadc_step_config(struct tiadc_device *adc_dev)
++static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ {
+ 	unsigned int stepconfig;
+ 	int i, steps;
+@@ -72,7 +86,11 @@ static void tiadc_step_config(struct tiadc_device *adc_dev)
+ 	 */
+ 
+ 	steps = TOTAL_STEPS - adc_dev->channels;
+-	stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++	if (mode == 0)
++            stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++	else
++			stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
++			| STEPCONFIG_MODE_SWCNT;
+ 
+ 	for (i = 0; i < adc_dev->channels; i++) {
+ 		int chan;
+@@ -88,6 +106,226 @@ static void tiadc_step_config(struct tiadc_device *adc_dev)
+ 
+ }
+ 
++static ssize_t tiadc_show_mode(struct device *dev,
++                struct device_attribute *attr, char *buf)
++{
++        struct iio_dev *indio_dev = dev_get_drvdata(dev);
++        struct tiadc_device *adc_dev = iio_priv(indio_dev);
++        unsigned int tmp;
++
++        tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
++        tmp &= STEPCONFIG_MODE(1);
++
++        if (tmp == 0x00)
++                return sprintf(buf, "oneshot\n");
++        else if (tmp == 0x01)
++                return sprintf(buf, "continuous\n");
++        else
++                return sprintf(buf, "Operation mode unknown\n");
++}
++
++static ssize_t tiadc_set_mode(struct device *dev,
++                struct device_attribute *attr, const char *buf, size_t count)
++{
++        struct iio_dev *indio_dev = dev_get_drvdata(dev);
++        struct tiadc_device *adc_dev = iio_priv(indio_dev);
++        unsigned config;
++
++        config = tiadc_readl(adc_dev, REG_CTRL);
++        config &= ~(CNTRLREG_TSCSSENB);
++        tiadc_writel(adc_dev, REG_CTRL, config);
++
++	if (!strncmp(buf, "oneshot", 7))
++               adc_dev->is_continuous_mode = false;
++        else if (!strncmp(buf, "continuous", 10))
++                adc_dev->is_continuous_mode = true;
++        else {
++                dev_err(dev, "Operational mode unknown\n");
++                return -EINVAL;
++        }
++ 
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
++        config = tiadc_readl(adc_dev, REG_CTRL);
++        tiadc_writel(adc_dev, REG_CTRL,
++                        (config | CNTRLREG_TSCSSENB));
++        return count;
++}
++
++static IIO_DEVICE_ATTR(mode, S_IRUGO | S_IWUSR, tiadc_show_mode,
++                tiadc_set_mode, 0);
++
++static struct attribute *tiadc_attributes[] = {
++        &iio_dev_attr_mode.dev_attr.attr,
++        NULL,
++};
++
++static const struct attribute_group tiadc_attribute_group = {
++        .attrs = tiadc_attributes,
++};
++
++static irqreturn_t tiadc_irq(int irq, void *private)
++{
++        struct iio_dev *idev = private;
++        struct tiadc_device *adc_dev = iio_priv(idev);
++	unsigned int status, config;
++
++        status = tiadc_readl(adc_dev, REG_IRQSTATUS);
++        if (status & IRQENB_FIFO1THRES) {
++                tiadc_writel(adc_dev, REG_IRQCLR,
++                                IRQENB_FIFO1THRES);
++
++                if (iio_buffer_enabled(idev)) {
++                        if (!work_pending(&adc_dev->poll_work))
++                                schedule_work(&adc_dev->poll_work);
++                } else {
++                        wake_up_interruptible(&adc_dev->wq_data_avail);
++                }
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                (status | IRQENB_FIFO1THRES));
++                return IRQ_HANDLED;
++        } else if ((status &  IRQENB_FIFO1OVRRUN) ||
++                        (status &  IRQENB_FIFO1UNDRFLW)) {
++                config = tiadc_readl(adc_dev,  REG_CTRL);
++                config &= ~( CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev,  REG_CTRL, config);
++ 
++                if (status &  IRQENB_FIFO1UNDRFLW)
++                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                        (status |  IRQENB_FIFO1UNDRFLW));
++                else
++                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                                (status |  IRQENB_FIFO1OVRRUN));
++ 
++                tiadc_writel(adc_dev,  REG_CTRL,
++                        (config |  CNTRLREG_TSCSSENB));
++                return IRQ_HANDLED;        
++	} else {
++                return IRQ_NONE;
++        }
++}
++
++static void tiadc_poll_handler(struct work_struct *work_s)
++{
++        struct tiadc_device *adc_dev =
++                container_of(work_s, struct tiadc_device, poll_work);
++        struct iio_dev *idev = iio_priv_to_dev(adc_dev);
++        struct iio_buffer *buffer = idev->buffer;
++        unsigned int fifo1count, readx1, status;
++        int i;
++        u32 *iBuf;
++
++        fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++        iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
++        if (iBuf == NULL)
++                return;
++        /*
++         * Wait for ADC sequencer to settle down.
++         * There could be a scenario where in we
++         * try to read data from ADC before
++         * it is available.
++         */
++        udelay(500);
++
++        for (i = 0; i < fifo1count; i++) {
++                readx1 = tiadc_readl(adc_dev, REG_FIFO1);
++                readx1 &= FIFOREAD_DATA_MASK;
++                iBuf[i] = readx1;
++        }
++
++        buffer->access->store_to(buffer, (u8 *) iBuf);
++        status = tiadc_readl(adc_dev, REG_IRQENABLE);
++        tiadc_writel(adc_dev, REG_IRQENABLE,
++                        (status | IRQENB_FIFO1THRES));
++
++        kfree(iBuf);
++}
++
++static int tiadc_buffer_preenable(struct iio_dev *idev)
++{
++        struct iio_buffer *buffer = idev->buffer;
++
++        buffer->access->set_bytes_per_datum(buffer, 16);
++        return 0;
++}
++
++static int tiadc_buffer_postenable(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++        struct iio_buffer *buffer = idev->buffer;
++        unsigned int enb, status, fifo1count;
++        int stepnum, i;
++        u8 bit;
++
++        if (!adc_dev->is_continuous_mode) {
++                printk("Data cannot be read continuously in one shot mode\n");
++                return -EINVAL;
++        } else {
++                status = tiadc_readl(adc_dev, REG_IRQENABLE);
++                tiadc_writel(adc_dev, REG_IRQENABLE,
++                                (status | IRQENB_FIFO1THRES)|
++                                 IRQENB_FIFO1OVRRUN |
++                                 IRQENB_FIFO1UNDRFLW);
++
++                fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++                for (i = 0; i < fifo1count; i++)
++                        tiadc_readl(adc_dev, REG_FIFO1);
++
++                tiadc_writel(adc_dev, REG_SE, 0x00);
++                for_each_set_bit(bit, buffer->scan_mask,
++                                adc_dev->channels) {
++                        struct iio_chan_spec const *chan = idev->channels + bit;
++                        /*
++                         * There are a total of 16 steps available
++                         * that are shared between ADC and touchscreen.
++                         * We start configuring from step 16 to 0 incase of
++                         * ADC. Hence the relation between input channel
++                         * and step for ADC would be as below.
++                         */
++                        stepnum = chan->channel + 9;
++                        enb = tiadc_readl(adc_dev, REG_SE);
++                        enb |= (1 << stepnum);
++                        tiadc_writel(adc_dev, REG_SE, enb);
++                }
++                return 0;
++        }
++}
++
++static int tiadc_buffer_postdisable(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++  
++	tiadc_writel(adc_dev, REG_IRQCLR, (IRQENB_FIFO1THRES |
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW));
++        tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
++        return 0;
++}
++
++static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
++        .preenable = &tiadc_buffer_preenable,
++        .postenable = &tiadc_buffer_postenable,
++        .postdisable = &tiadc_buffer_postdisable,
++};
++
++static int tiadc_config_sw_ring(struct iio_dev *idev)
++{
++        struct tiadc_device *adc_dev = iio_priv(idev);
++      //int ret;
++
++        idev->buffer = iio_kfifo_allocate(idev);
++        if (!idev->buffer)
++                return(-ENOMEM);
++
++ //     idev->buffer->access = &ring_sw_access_funcs;
++        idev->setup_ops = &tiadc_buffer_setup_ops;
++
++        INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
++
++        idev->modes |= INDIO_BUFFER_HARDWARE;
++        return 0;
++}
++
+ static const char * const chan_name_ain[] = {
+ 	"AIN0",
+ 	"AIN1",
+@@ -121,6 +359,7 @@ static int tiadc_channel_init(struct iio_dev *indio_dev, int channels)
+ 		chan->info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+ 						BIT(IIO_CHAN_INFO_SCALE);
+ 		chan->datasheet_name = chan_name_ain[chan->channel];
++		chan->scan_index = i;
+ 		chan->scan_type.sign = 'u';
+ 		chan->scan_type.realbits = 12;
+ 		chan->scan_type.storagebits = 32;
+@@ -148,68 +387,76 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 	u32 step_en;
+ 	unsigned long timeout = jiffies + usecs_to_jiffies
+ 				(IDLE_TIMEOUT * adc_dev->channels);
+-	step_en = get_adc_step_mask(adc_dev);
+-	am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
+- 
+-	/* Wait for ADC sequencer to complete sampling */
+-	while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
+-		if (time_after(jiffies, timeout))
+-			return -EAGAIN;
+-		}
+-	map_val = chan->channel + TOTAL_CHANNELS;
+ 
+-	/*
+-	 * When the sub-system is first enabled,
+-	 * the sequencer will always start with the
+-	 * lowest step (1) and continue until step (16).
+-	 * For ex: If we have enabled 4 ADC channels and
+-	 * currently use only 1 out of them, the
+-	 * sequencer still configures all the 4 steps,
+-	 * leading to 3 unwanted data.
+-	 * Hence we need to flush out this data.
+-	 */
+-
+-	for (i = 0; i < ARRAY_SIZE(adc_dev->channel_step); i++) {
+-		if (chan->channel == adc_dev->channel_line[i]) {
+-			step = adc_dev->channel_step[i];
+-			break;
++       if (adc_dev->is_continuous_mode) {
++               printk("One shot mode not enabled\n");
++               return -EINVAL;
++       } else {
++
++		step_en = get_adc_step_mask(adc_dev);
++		am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
++	 
++		/* Wait for ADC sequencer to complete sampling */
++		while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
++			if (time_after(jiffies, timeout))
++				return -EAGAIN;
++			}
++		map_val = chan->channel + TOTAL_CHANNELS;
++
++		/*
++		 * When the sub-system is first enabled,
++		 * the sequencer will always start with the
++		 * lowest step (1) and continue until step (16).
++		 * For ex: If we have enabled 4 ADC channels and
++		 * currently use only 1 out of them, the
++		 * sequencer still configures all the 4 steps,
++		 * leading to 3 unwanted data.
++		 * Hence we need to flush out this data.
++		 */
++
++		for (i = 0; i < ARRAY_SIZE(adc_dev->channel_step); i++) {
++			if (chan->channel == adc_dev->channel_line[i]) {
++				step = adc_dev->channel_step[i];
++				break;
++			}
+ 		}
+-	}
+-	if (WARN_ON_ONCE(step == UINT_MAX))
+-		return -EINVAL;
+-
+-	fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-	for (i = 0; i < fifo1count; i++) {
+-		read = tiadc_readl(adc_dev, REG_FIFO1);
+-		stepid = read & FIFOREAD_CHNLID_MASK;
+-		stepid = stepid >> 0x10;
+-
+-		if (stepid == map_val) {
+-			read = read & FIFOREAD_DATA_MASK;
+-			found = true;
+-			*val = read;
++		if (WARN_ON_ONCE(step == UINT_MAX))
++			return -EINVAL;
++
++		fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++		for (i = 0; i < fifo1count; i++) {
++			read = tiadc_readl(adc_dev, REG_FIFO1);
++			stepid = read & FIFOREAD_CHNLID_MASK;
++			stepid = stepid >> 0x10;
++
++			if (stepid == map_val) {
++				read = read & FIFOREAD_DATA_MASK;
++				found = true;
++				*val = read;
++			}
+ 		}
+-	}
+ 
+-	switch (mask){
+-		case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
+-					break;
+-		case IIO_CHAN_INFO_SCALE : {
+-			/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
+-			AVDD should come from DT.*/
+-			*val = div_u64( (u64)(*val) * 1800 , 4096);
+-			break;
++		switch (mask){
++			case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
++						break;
++			case IIO_CHAN_INFO_SCALE : {
++				/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
++				AVDD should come from DT.*/
++				*val = div_u64( (u64)(*val) * 1800 , 4096);
++				break;
++			}
++			default: break;
+ 		}
+-		default: break;
+-	}
+ 
+-	if (found == false)
+-		return -EBUSY;
+-	return IIO_VAL_INT;
++		if (found == false)
++			return -EBUSY;
++		return IIO_VAL_INT;
++	}
+ }
+ 
+ static const struct iio_info tiadc_info = {
+ 	.read_raw = &tiadc_read_raw,
++	.attrs = &tiadc_attribute_group,
+ };
+ 
+ static int tiadc_probe(struct platform_device *pdev)
+@@ -243,17 +490,37 @@ static int tiadc_probe(struct platform_device *pdev)
+ 		channels++;
+ 	}
+ 	adc_dev->channels = channels;
++	adc_dev->irq = adc_dev->mfd_tscadc->irq;
+ 
+ 	indio_dev->dev.parent = &pdev->dev;
+ 	indio_dev->name = dev_name(&pdev->dev);
+ 	indio_dev->modes = INDIO_DIRECT_MODE;
+ 	indio_dev->info = &tiadc_info;
+ 
+-	tiadc_step_config(adc_dev);
++	/* by default driver comes up with oneshot mode */
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
++	/* program FIFO threshold to value minus 1 */
++	tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+ 
+ 	err = tiadc_channel_init(indio_dev, adc_dev->channels);
+ 	if (err < 0)
+ 		goto err_free_device;
++    init_waitqueue_head(&adc_dev->wq_data_avail);
++
++    err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
++            indio_dev->name, indio_dev);
++    if (err)
++            goto err_free_irq;
++
++    err = tiadc_config_sw_ring(indio_dev);
++    if (err < 0)
++            goto err_unregister;
++ 
++    err = iio_buffer_register(indio_dev,
++                    indio_dev->channels, indio_dev->num_channels);
++    if (err < 0)
++            goto err_unregister;
+ 
+ 	err = iio_device_register(indio_dev);
+ 	if (err)
+@@ -263,6 +530,10 @@ static int tiadc_probe(struct platform_device *pdev)
+ 
+ 	return 0;
+ 
++err_unregister:
++
++err_free_irq:
++   free_irq(adc_dev->irq, indio_dev);
+ err_free_channels:
+ 	tiadc_channels_remove(indio_dev);
+ err_free_device:
+@@ -313,13 +584,14 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
++    tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
++    tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++
+ 	/* Make sure ADC is powered up */
+ 	restore = tiadc_readl(adc_dev, REG_CTRL);
+ 	restore &= ~(CNTRLREG_POWERDOWN);
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+-	tiadc_step_config(adc_dev);
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index cf56cae..4bf2ee6 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -263,11 +263,14 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+  
+         /*
+          * ADC and touchscreen share the IRQ line.
+-         * FIFO1 threshold interrupt is used by ADC,
++         * FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
++         * interrupts are used by ADC,
+          * hence return from touchscreen IRQ handler if FIFO1
+-         * threshold interrupt occurred.
++         * related interrupts occurred.
+          */
+-        if (status & IRQENB_FIFO1THRES)
++       if ((status & IRQENB_FIFO1THRES) ||
++                       (status & IRQENB_FIFO1OVRRUN) ||
++                       (status & IRQENB_FIFO1UNDRFLW))
+                 return IRQ_NONE;
+         else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index d72001c..fdbd0d5 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -282,6 +282,8 @@ static int tscadc_suspend(struct device *dev)
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+ 
+ 	tscadc_writel(tscadc_dev, REG_SE, 0x00);
++        tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
++        tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
+ 	pm_runtime_put_sync(dev);
+ 
+ 	return 0;
+@@ -290,22 +292,16 @@ static int tscadc_suspend(struct device *dev)
+ static int tscadc_resume(struct device *dev)
+ {
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+-	unsigned int restore, ctrl;
+ 
+ 	pm_runtime_get_sync(dev);
+ 
+ 	/* context restore */
+-	ctrl = CNTRLREG_STEPCONFIGWRT |	CNTRLREG_STEPID;
+-	if (tscadc_dev->tsc_cell != -1)
+-		ctrl |= CNTRLREG_TSCENB | CNTRLREG_4WIRE;
+-	tscadc_writel(tscadc_dev, REG_CTRL, ctrl);
++	tscadc_writel(tscadc_dev, REG_IRQENABLE, tscadc_dev->irqstat);
+ 
+ 	if (tscadc_dev->tsc_cell != -1)
+ 		tscadc_idle_config(tscadc_dev);
+ 	am335x_tsc_se_update(tscadc_dev);
+-	restore = tscadc_readl(tscadc_dev, REG_CTRL);
+-	tscadc_writel(tscadc_dev, REG_CTRL,
+-			(restore | CNTRLREG_TSCSSENB));
++        tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
+ 
+ 	return 0;
+ }
+diff --git a/include/linux/mfd/ti_am335x_tscadc.h b/include/linux/mfd/ti_am335x_tscadc.h
+index db1791b..f436918 100644
+--- a/include/linux/mfd/ti_am335x_tscadc.h
++++ b/include/linux/mfd/ti_am335x_tscadc.h
+@@ -46,17 +46,23 @@
+ /* Step Enable */
+ #define STEPENB_MASK		(0x1FFFF << 0)
+ #define STEPENB(val)		((val) << 0)
++#define ENB(val)                        (1 << (val))
++#define STPENB_STEPENB          STEPENB(0x1FFFF)
++#define STPENB_STEPENB_TC       STEPENB(0x1FFF)
+ 
+ /* IRQ enable */
+ #define IRQENB_HW_PEN		BIT(0)
+ #define IRQENB_FIFO0THRES	BIT(2)
+ #define IRQENB_FIFO1THRES	BIT(5)
+ #define IRQENB_PENUP		BIT(9)
++#define IRQENB_FIFO1OVRRUN       BIT(6)
++#define IRQENB_FIFO1UNDRFLW      BIT(7)
+ 
+ /* Step Configuration */
+ #define STEPCONFIG_MODE_MASK	(3 << 0)
+ #define STEPCONFIG_MODE(val)	((val) << 0)
+ #define STEPCONFIG_MODE_HWSYNC	STEPCONFIG_MODE(2)
++#define STEPCONFIG_MODE_SWCNT   STEPCONFIG_MODE(1)
+ #define STEPCONFIG_AVG_MASK	(7 << 2)
+ #define STEPCONFIG_AVG(val)	((val) << 2)
+ #define STEPCONFIG_AVG_16	STEPCONFIG_AVG(4)
+@@ -124,6 +130,7 @@
+ #define	MAX_CLK_DIV		7
+ #define TOTAL_STEPS		16
+ #define TOTAL_CHANNELS		8
++#define FIFO1_THRESHOLD                        19
+ 
+ /*
+ * ADC runs at 3MHz, and it takes
+@@ -153,6 +160,11 @@ struct ti_tscadc_dev {
+ 
+ 	/* adc device */
+ 	struct adc_device *adc;
++
++    /* Context save */
++    unsigned int irqstat;
++    unsigned int ctrl;
++
+ };
+ 
+ static inline struct ti_tscadc_dev *ti_tscadc_dev_get(struct platform_device *p)
+-- 
+1.7.9.5
+

--- a/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
+++ b/patches/adc/0007-MFD-ti_tscadc-ADC-Clock-check-not-required.patch
@@ -1,0 +1,55 @@
+From a87576da540cd7eb0f90fef47992ee3c3af07f02 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 22:54:41 +0100
+Subject: [PATCH 07/22] MFD: ti_tscadc: ADC Clock check not required
+
+ADC is ideally expected to work at a frequency of 3MHz.
+
+The present code had a check, which returned error if the frequency
+
+went below the threshold  value. But since AM335x supports various
+
+working frequencies, this check is not required.
+
+Now the code just uses the internal ADC clock divider to set the ADC
+
+frequency w.r.t the sys clock.
+
+Signed-off-by: Patil, Rachna <rachna@ti.com>
+---
+ drivers/mfd/ti_am335x_tscadc.c       |    6 +-----
+ include/linux/mfd/ti_am335x_tscadc.h |    1 -
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index fdbd0d5..e7314e4 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -197,11 +197,7 @@ static	int ti_tscadc_probe(struct platform_device *pdev)
+ 	clock_rate = clk_get_rate(clk);
+ 	clk_put(clk);
+ 	clk_value = clock_rate / ADC_CLK;
+-	if (clk_value < MAX_CLK_DIV) {
+-		dev_err(&pdev->dev, "clock input less than min clock requirement\n");
+-		err = -EINVAL;
+-		goto err_disable_clk;
+-	}
++
+ 	/* TSCADC_CLKDIV needs to be configured to the value minus 1 */
+ 	clk_value = clk_value - 1;
+ 	tscadc_writel(tscadc, REG_CLKDIV, clk_value);
+diff --git a/include/linux/mfd/ti_am335x_tscadc.h b/include/linux/mfd/ti_am335x_tscadc.h
+index f436918..1516dc8 100644
+--- a/include/linux/mfd/ti_am335x_tscadc.h
++++ b/include/linux/mfd/ti_am335x_tscadc.h
+@@ -127,7 +127,6 @@
+ #define SEQ_STATUS BIT(5)
+ 
+ #define ADC_CLK			3000000
+-#define	MAX_CLK_DIV		7
+ #define TOTAL_STEPS		16
+ #define TOTAL_CHANNELS		8
+ #define FIFO1_THRESHOLD                        19
+-- 
+1.7.9.5
+

--- a/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
+++ b/patches/adc/0008-iio-TI-am335x-adc-Cleanup.patch
@@ -1,0 +1,89 @@
+From b204a63037419bcf61d1bcf452db6fb3129f1702 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:03:09 +0100
+Subject: [PATCH 08/22] iio: TI-am335x-adc: Cleanup
+
+Cleaned up the code a bit. Some formatting.
+Some error handling paths corrected
+---
+ drivers/iio/adc/ti_am335x_adc.c |   33 +++++++++++++++++----------------
+ 1 file changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1f6e800..31665fa 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -311,13 +311,11 @@ static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
+ static int tiadc_config_sw_ring(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+-      //int ret;
+ 
+         idev->buffer = iio_kfifo_allocate(idev);
+         if (!idev->buffer)
+                 return(-ENOMEM);
+ 
+- //     idev->buffer->access = &ring_sw_access_funcs;
+         idev->setup_ops = &tiadc_buffer_setup_ops;
+ 
+         INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
+@@ -506,21 +504,22 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	err = tiadc_channel_init(indio_dev, adc_dev->channels);
+ 	if (err < 0)
+ 		goto err_free_device;
+-    init_waitqueue_head(&adc_dev->wq_data_avail);
+ 
+-    err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
+-            indio_dev->name, indio_dev);
+-    if (err)
+-            goto err_free_irq;
++	init_waitqueue_head(&adc_dev->wq_data_avail);
+ 
+-    err = tiadc_config_sw_ring(indio_dev);
+-    if (err < 0)
+-            goto err_unregister;
++	err = request_irq(adc_dev->irq, tiadc_irq, IRQF_SHARED,
++		indio_dev->name, indio_dev);
++	if (err)
++		goto err_free_irq;
++
++	err = tiadc_config_sw_ring(indio_dev);
++	if (err < 0)
++		goto err_unregister;
+  
+-    err = iio_buffer_register(indio_dev,
+-                    indio_dev->channels, indio_dev->num_channels);
+-    if (err < 0)
+-            goto err_unregister;
++	err = iio_buffer_register(indio_dev,
++		indio_dev->channels, indio_dev->num_channels);
++	if (err < 0)
++		goto err_unregister;
+ 
+ 	err = iio_device_register(indio_dev);
+ 	if (err)
+@@ -531,9 +530,9 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	return 0;
+ 
+ err_unregister:
+-
++	iio_buffer_unregister(indio_dev);
+ err_free_irq:
+-   free_irq(adc_dev->irq, indio_dev);
++	free_irq(adc_dev->irq, indio_dev);
+ err_free_channels:
+ 	tiadc_channels_remove(indio_dev);
+ err_free_device:
+@@ -548,7 +547,9 @@ static int tiadc_remove(struct platform_device *pdev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	u32 step_en;
+ 
++	free_irq(adc_dev->irq, indio_dev);
+ 	iio_device_unregister(indio_dev);
++	iio_buffer_unregister(indio_dev);
+ 	tiadc_channels_remove(indio_dev);
+ 
+ 	step_en = get_adc_step_mask(adc_dev);
+-- 
+1.7.9.5
+

--- a/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
+++ b/patches/adc/0009-IIO-ti_adc-Handle-set-to-clear-IRQENABLE-register-pr.patch
@@ -1,0 +1,82 @@
+From bda047e53bee855b1849fc3726495fd573dbc71a Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:34:25 +0100
+Subject: [PATCH 09/22] IIO: ti_adc: Handle set to clear IRQENABLE register
+ properly.
+
+The driver is currently mishandling the IRQENABLE register. The driver
+
+should write a 1 for bits it wishes to set, and a zero for bits it does not
+
+wish to change. The read of the current register contents is not
+
+necessary.
+
+Write 0 = No action.
+
+Read 0 = Interrupt disabled (masked).
+
+Read 1 = Interrupt enabled.
+
+Write 1 = Enable interrupt.
+
+The current read/update/write method is currently not causing any
+
+problems, but could cause confusion in the future.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 31665fa..a86830b 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -211,7 +211,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+                 container_of(work_s, struct tiadc_device, poll_work);
+         struct iio_dev *idev = iio_priv_to_dev(adc_dev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int fifo1count, readx1, status;
++        unsigned int fifo1count, readx1;
+         int i;
+         u32 *iBuf;
+ 
+@@ -234,9 +234,8 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
+-        status = tiadc_readl(adc_dev, REG_IRQENABLE);
+-        tiadc_writel(adc_dev, REG_IRQENABLE,
+-                        (status | IRQENB_FIFO1THRES));
++        tiadc_writel(adc_dev, REG_IRQENABLE, 
++				IRQENB_FIFO1THRES);
+ 
+         kfree(iBuf);
+ }
+@@ -253,7 +252,7 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, status, fifo1count;
++        unsigned int enb, fifo1count;
+         int stepnum, i;
+         u8 bit;
+ 
+@@ -261,11 +260,10 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+                 printk("Data cannot be read continuously in one shot mode\n");
+                 return -EINVAL;
+         } else {
+-                status = tiadc_readl(adc_dev, REG_IRQENABLE);
+                 tiadc_writel(adc_dev, REG_IRQENABLE,
+-                                (status | IRQENB_FIFO1THRES)|
++                                (IRQENB_FIFO1THRES |
+                                  IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW);
++                                 IRQENB_FIFO1UNDRFLW));
+ 
+                 fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+                 for (i = 0; i < fifo1count; i++)
+-- 
+1.7.9.5
+

--- a/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
+++ b/patches/adc/0010-IIO-ti_adc-Handle-set-to-clear-IRQSTATUS-register-pr.patch
@@ -1,0 +1,61 @@
+From 06f887a51c82f83f6e4a24d2ff9e59db28d59b9d Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:42:38 +0100
+Subject: [PATCH 10/22] IIO: ti_adc: Handle set to clear IRQSTATUS register
+ properly
+
+The driver is currently mishandling the IRQSTATUS register by peforming
+
+a read/update/write cycle. The actual functionality of the register is as follows:
+
+Write 0 = No action.
+
+Read 0 = No (enabled) event pending.
+
+Read 1 = Event pending.
+
+Write 1 = Clear (raw) event.
+
+By reading the status and writing it back, the driver is clearing
+
+all pending events, not just the one indicated in the bitmask.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   13 +++++--------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index a86830b..5c95eba 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -182,7 +182,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                         wake_up_interruptible(&adc_dev->wq_data_avail);
+                 }
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                (status | IRQENB_FIFO1THRES));
++					IRQENB_FIFO1THRES);
+                 return IRQ_HANDLED;
+         } else if ((status &  IRQENB_FIFO1OVRRUN) ||
+                         (status &  IRQENB_FIFO1UNDRFLW)) {
+@@ -190,13 +190,10 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 config &= ~( CNTRLREG_TSCSSENB);
+                 tiadc_writel(adc_dev,  REG_CTRL, config);
+  
+-                if (status &  IRQENB_FIFO1UNDRFLW)
+-                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                        (status |  IRQENB_FIFO1UNDRFLW));
+-                else
+-                        tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                                (status |  IRQENB_FIFO1OVRRUN));
+- 
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW);
++
+                 tiadc_writel(adc_dev,  REG_CTRL,
+                         (config |  CNTRLREG_TSCSSENB));
+                 return IRQ_HANDLED;        
+-- 
+1.7.9.5
+

--- a/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
+++ b/patches/adc/0011-IIO-ti_adc-Handle-overrun-before-threshold-event.patch
@@ -1,0 +1,64 @@
+From 0da0bb41a0b72899c5d52f758063cf9a68a5703d Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:46:59 +0100
+Subject: [PATCH 11/22] IIO: ti_adc: Handle overrun before threshold event
+
+If an overrun occurs, the threshold event is meaningless, handle
+
+the overrun event first.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   29 ++++++++++++++---------------
+ 1 file changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 5c95eba..e510da7 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -171,7 +171,19 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+ 	unsigned int status, config;
+ 
+         status = tiadc_readl(adc_dev, REG_IRQSTATUS);
+-        if (status & IRQENB_FIFO1THRES) {
++        if (status & IRQENB_FIFO1OVRRUN) {
++                config = tiadc_readl(adc_dev, REG_CTRL);
++                config &= ~(CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev, REG_CTRL, config);
++
++                tiadc_writel(adc_dev, REG_IRQSTATUS,
++                                IRQENB_FIFO1OVRRUN |
++                                IRQENB_FIFO1UNDRFLW);
++ 
++                tiadc_writel(adc_dev, REG_CTRL,
++                       (config | CNTRLREG_TSCSSENB));
++		return IRQ_HANDLED;
++        } else if (status & IRQENB_FIFO1THRES) {
+                 tiadc_writel(adc_dev, REG_IRQCLR,
+                                 IRQENB_FIFO1THRES);
+ 
+@@ -183,20 +195,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 }
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 					IRQENB_FIFO1THRES);
+-                return IRQ_HANDLED;
+-        } else if ((status &  IRQENB_FIFO1OVRRUN) ||
+-                        (status &  IRQENB_FIFO1UNDRFLW)) {
+-                config = tiadc_readl(adc_dev,  REG_CTRL);
+-                config &= ~( CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev,  REG_CTRL, config);
+- 
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW);
+-
+-                tiadc_writel(adc_dev,  REG_CTRL,
+-                        (config |  CNTRLREG_TSCSSENB));
+-                return IRQ_HANDLED;        
++                return IRQ_HANDLED;      
+ 	} else {
+                 return IRQ_NONE;
+         }
+-- 
+1.7.9.5
+

--- a/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
+++ b/patches/adc/0012-iio-ti_adc-Avoid-double-threshold-event.patch
@@ -1,0 +1,60 @@
+From b0f24b422e9d2946d6d20e1f23fde8e42529cd55 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:49:48 +0100
+Subject: [PATCH 12/22] iio: ti_adc: Avoid double threshold event
+
+The threshold event handler is being called before the FIFO has
+
+actually reached the threshold.
+
+The current code receives a FIFO threshold event, masks the interrupt,
+
+clears the event, and schedules a workqueue. The workqueue is run, it
+
+empties the FIFO, and unmasks the interrupt.
+
+In the above sequence, after the event is cleared, it immediately
+
+retriggers since the FIFO remains beyond the threshold. When the IRQ is
+
+unmasked, this triggered event generates another IRQ. However, as the
+
+FIFO has just been emptied, it is likely to not contain enough samples.
+
+The waits to clear the event until the FIFO has actually been emptied,
+
+in the workqueue. The unmasking and masking of the interrupt remains
+
+unchanged.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index e510da7..fcd414d 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -193,8 +193,7 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+                 } else {
+                         wake_up_interruptible(&adc_dev->wq_data_avail);
+                 }
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-					IRQENB_FIFO1THRES);
++
+                 return IRQ_HANDLED;      
+ 	} else {
+                 return IRQ_NONE;
+@@ -230,6 +229,8 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
++	tiadc_writel(adc_dev, REG_IRQSTATUS,
++				IRQENB_FIFO1THRES);
+         tiadc_writel(adc_dev, REG_IRQENABLE, 
+ 				IRQENB_FIFO1THRES);
+ 
+-- 
+1.7.9.5
+

--- a/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
+++ b/patches/adc/0013-IIO-ti_adc-Also-clear-threshold-event-when-clearing-.patch
@@ -1,0 +1,34 @@
+From 48fc0286ef2b26dba6aa6c1d0ddf375702ab162c Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Thu, 11 Jul 2013 23:53:46 +0100
+Subject: [PATCH 13/22] IIO: ti_adc: Also clear threshold event when clearing
+ overrun event
+
+When an overrun occurs, the FIFO is cleared. If a FIFO threshold event
+
+was pending, the data is now gone. Clear the threshold event when
+
+handling an overrun (or underflow).
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index fcd414d..1e48799 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -178,7 +178,8 @@ static irqreturn_t tiadc_irq(int irq, void *private)
+ 
+                 tiadc_writel(adc_dev, REG_IRQSTATUS,
+                                 IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW);
++                                IRQENB_FIFO1UNDRFLW |
++                                IRQENB_FIFO1THRES);
+  
+                 tiadc_writel(adc_dev, REG_CTRL,
+                        (config | CNTRLREG_TSCSSENB));
+-- 
+1.7.9.5
+

--- a/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
+++ b/patches/adc/0014-IO-ti_adc-Reset-and-clear-overrun-status-before-capt.patch
@@ -1,0 +1,62 @@
+From cbb646469711967af0b4443741e0dd28d549c643 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 00:01:41 +0100
+Subject: [PATCH 14/22] IO: ti_adc: Reset and clear overrun status before
+ capture.
+
+While not pulling out samples, the FIFO will fill up causing an
+
+overrun event. Before starting up another continuous sample, clear that
+
+event.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |   24 +++++++++++++++---------
+ 1 file changed, 15 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1e48799..eb47385 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -250,22 +250,28 @@ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+         struct tiadc_device *adc_dev = iio_priv(idev);
+         struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, fifo1count;
+-        int stepnum, i;
++        unsigned int enb, config;
++        int stepnum;
+         u8 bit;
+ 
+         if (!adc_dev->is_continuous_mode) {
+                 printk("Data cannot be read continuously in one shot mode\n");
+                 return -EINVAL;
+         } else {
+-                tiadc_writel(adc_dev, REG_IRQENABLE,
+-                                (IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW));
+ 
+-                fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-                for (i = 0; i < fifo1count; i++)
+-                        tiadc_readl(adc_dev, REG_FIFO1);
++                config = tiadc_readl(adc_dev, REG_CTRL);
++                tiadc_writel(adc_dev, REG_CTRL,
++                                        config & ~CNTRLREG_TSCSSENB);
++                tiadc_writel(adc_dev, REG_CTRL,
++                                        config |  CNTRLREG_TSCSSENB);
++
++                tiadc_writel(adc_dev,  REG_IRQSTATUS,
++                                 IRQENB_FIFO1THRES |
++                                 IRQENB_FIFO1OVRRUN |
++                                 IRQENB_FIFO1UNDRFLW);
++                tiadc_writel(adc_dev,  REG_IRQENABLE,
++                                 IRQENB_FIFO1THRES |
++                                 IRQENB_FIFO1OVRRUN);
+ 
+                 tiadc_writel(adc_dev, REG_SE, 0x00);
+                 for_each_set_bit(bit, buffer->scan_mask,
+-- 
+1.7.9.5
+

--- a/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
+++ b/patches/adc/0015-IIO-ti_adc-Properly-handle-out-of-memory-situation.patch
@@ -1,0 +1,55 @@
+From a4dea7423ba82a89b6d931d2b4735233f02d0565 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:02:43 +0100
+Subject: [PATCH 15/22] IIO: ti_adc: Properly handle out of memory situation.
+
+If we fail to allocate a buffer, unmask the interrupt to allow a retry.
+
+The interrupt handler will be re-run, and our workqueue rescheduled.
+
+If we are able to allocate memory next time around, everything will
+
+continue as normal, otherwise, we will eventually get an underrun.
+
+Before this patch, the driver would stop capturing without any
+
+indication of error to the IIO subsystem or the user.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index eb47385..69abde0 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -214,7 +214,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+         iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+-                return;
++                goto out;
+         /*
+          * Wait for ADC sequencer to settle down.
+          * There could be a scenario where in we
+@@ -230,12 +230,14 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         }
+ 
+         buffer->access->store_to(buffer, (u8 *) iBuf);
++	kfree(iBuf);
++
++out:	
+ 	tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 				IRQENB_FIFO1THRES);
+         tiadc_writel(adc_dev, REG_IRQENABLE, 
+ 				IRQENB_FIFO1THRES);
+-
+-        kfree(iBuf);
++    
+ }
+ 
+ static int tiadc_buffer_preenable(struct iio_dev *idev)
+-- 
+1.7.9.5
+

--- a/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
+++ b/patches/adc/0016-IIO-ti_adc-Print-error-and-handle-short-FIFO-events.patch
@@ -1,0 +1,43 @@
+From b3aba5bce5c90aab9929931ae24cf281685e923e Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:05:22 +0100
+Subject: [PATCH 16/22] IIO: ti_adc: Print error and handle short FIFO events
+
+In the case that the FIFO threshold handler gets called when the
+
+FIFO has not actually reached the threshold, the driver will pass
+
+uninitialized memory to the IIO subsystem.
+
+In the past, this would occur due to bugs in the driver, those bugs
+
+have been fixed. However, it is still a good idea to close this just
+
+in case additional bugs in hardware or software exist.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 69abde0..c257169 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -212,6 +212,13 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         u32 *iBuf;
+ 
+         fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++        if (fifo1count * sizeof(u32) <
++                                buffer->access->get_bytes_per_datum(buffer)) {
++                dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
++                                                                __func__);
++                goto out;
++        }
++
+         iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+-- 
+1.7.9.5
+

--- a/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
+++ b/patches/adc/0017-IIO-ti_adc-Fix-allocation-count-of-FIFO-buffer.patch
@@ -1,0 +1,30 @@
+From f2535b020f654f473e3814fe8326210aa78da22d Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:07:31 +0100
+Subject: [PATCH 17/22] IIO: ti_adc: Fix allocation count of FIFO buffer.
+
+Allocating an extra byte is not necessary here. The driver will check
+
+that the allocation is large enough to satisfy the IIO subsystem.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index c257169..21294f2 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -219,7 +219,7 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+                 goto out;
+         }
+ 
+-        iBuf = kmalloc((fifo1count + 1) * sizeof(u32), GFP_KERNEL);
++        iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+         /*
+-- 
+1.7.9.5
+

--- a/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
+++ b/patches/adc/0018-Revert-IIO-ti_adc-Correct-wrong-samples-received-on-.patch
@@ -1,0 +1,42 @@
+From 1871b4433db25af99c95342f2f627ed543bc1750 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:09:08 +0100
+Subject: [PATCH 18/22] Revert "IIO: ti_adc: Correct wrong samples received on
+ 1st read in continuous mode"
+
+With a proper fix to this code, this is no longer neccessary.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 21294f2..1f42e0a 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -36,7 +36,6 @@
+ #include <linux/iio/trigger_consumer.h>
+ #include <linux/iio/kfifo_buf.h>
+ #include <linux/iio/sysfs.h>
+-#include <linux/delay.h>
+ 
+ struct tiadc_device {
+ 	struct ti_tscadc_dev *mfd_tscadc;
+@@ -222,13 +221,6 @@ static void tiadc_poll_handler(struct work_struct *work_s)
+         iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+         if (iBuf == NULL)
+                 goto out;
+-        /*
+-         * Wait for ADC sequencer to settle down.
+-         * There could be a scenario where in we
+-         * try to read data from ADC before
+-         * it is available.
+-         */
+-        udelay(500);
+ 
+         for (i = 0; i < fifo1count; i++) {
+                 readx1 = tiadc_readl(adc_dev, REG_FIFO1);
+-- 
+1.7.9.5
+

--- a/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
+++ b/patches/adc/0019-IIO-ti_adc-Fix-capture-operation-during-resume.patch
@@ -1,0 +1,38 @@
+From e04c9bffd8c6abbfcfa373da059487ebd4b6a76d Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Fri, 12 Jul 2013 23:13:38 +0100
+Subject: [PATCH 19/22] IIO: ti_adc: Fix capture operation during resume
+
+The ADC needs to go through a proper initialization sequence after
+resuming from suspend.
+
+Signed-off-by: Russ Dill <Russ.Dill@ti.com>
+---
+ drivers/iio/adc/ti_am335x_adc.c |    6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 1f42e0a..40eec84 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -588,12 +588,16 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
++        restore = tiadc_readl(adc_dev, REG_CTRL);
++        restore &= ~(CNTRLREG_TSCSSENB);
++        tiadc_writel(adc_dev, REG_CTRL, restore);
++
+     tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+     tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+ 	/* Make sure ADC is powered up */
+-	restore = tiadc_readl(adc_dev, REG_CTRL);
+ 	restore &= ~(CNTRLREG_POWERDOWN);
++        restore |= CNTRLREG_TSCSSENB;
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+ 	return 0;
+-- 
+1.7.9.5
+

--- a/patches/adc/0020-iio-ti_amss5x-adc-Fix-check_patch.pl-issues.patch
+++ b/patches/adc/0020-iio-ti_amss5x-adc-Fix-check_patch.pl-issues.patch
@@ -1,0 +1,517 @@
+From 1c426d57c7a65ae9919d4587209a71545bfead7c Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sat, 13 Jul 2013 12:09:19 +0100
+Subject: [PATCH 20/22] iio: ti_amss5x adc Fix check_patch.pl issues
+
+all clear. replaced printk with pr_info..
+---
+ drivers/iio/adc/ti_am335x_adc.c |  375 ++++++++++++++++++++-------------------
+ 1 file changed, 188 insertions(+), 187 deletions(-)
+
+diff --git a/drivers/iio/adc/ti_am335x_adc.c b/drivers/iio/adc/ti_am335x_adc.c
+index 40eec84..b1438a7 100644
+--- a/drivers/iio/adc/ti_am335x_adc.c
++++ b/drivers/iio/adc/ti_am335x_adc.c
+@@ -44,9 +44,9 @@ struct tiadc_device {
+ 	u8 channel_step[8];
+ 	struct work_struct      poll_work;
+ 	wait_queue_head_t       wq_data_avail;
+-	int                     irq;
+-	bool                    is_continuous_mode;
+-        u16                     *buffer;
++	int		     irq;
++	bool		    is_continuous_mode;
++	u16		     *buffer;
+ };
+ 
+ static unsigned int tiadc_readl(struct tiadc_device *adc, unsigned int reg)
+@@ -69,7 +69,7 @@ static u32 get_adc_step_mask(struct tiadc_device *adc_dev)
+ 	return step_en;
+ }
+ 
+-static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
++static void tiadc_step_config(struct tiadc_device *adc_dev, bool mode)
+ {
+ 	unsigned int stepconfig;
+ 	int i, steps;
+@@ -86,10 +86,10 @@ static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ 
+ 	steps = TOTAL_STEPS - adc_dev->channels;
+ 	if (mode == 0)
+-            stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
++		stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1;
+ 	else
+-			stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
+-			| STEPCONFIG_MODE_SWCNT;
++		stepconfig = STEPCONFIG_AVG_16 | STEPCONFIG_FIFO1
++				| STEPCONFIG_MODE_SWCNT;
+ 
+ 	for (i = 0; i < adc_dev->channels; i++) {
+ 		int chan;
+@@ -106,225 +106,225 @@ static void tiadc_step_config(struct tiadc_device *adc_dev,bool mode)
+ }
+ 
+ static ssize_t tiadc_show_mode(struct device *dev,
+-                struct device_attribute *attr, char *buf)
++		struct device_attribute *attr, char *buf)
+ {
+-        struct iio_dev *indio_dev = dev_get_drvdata(dev);
+-        struct tiadc_device *adc_dev = iio_priv(indio_dev);
+-        unsigned int tmp;
+-
+-        tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
+-        tmp &= STEPCONFIG_MODE(1);
+-
+-        if (tmp == 0x00)
+-                return sprintf(buf, "oneshot\n");
+-        else if (tmp == 0x01)
+-                return sprintf(buf, "continuous\n");
+-        else
+-                return sprintf(buf, "Operation mode unknown\n");
++	struct iio_dev *indio_dev = dev_get_drvdata(dev);
++	struct tiadc_device *adc_dev = iio_priv(indio_dev);
++	unsigned int tmp;
++
++	tmp = tiadc_readl(adc_dev, REG_STEPCONFIG(TOTAL_STEPS));
++	tmp &= STEPCONFIG_MODE(1);
++
++	if (tmp == 0x00)
++		return sprintf(buf, "oneshot\n");
++	else if (tmp == 0x01)
++		return sprintf(buf, "continuous\n");
++	else
++		return sprintf(buf, "Operation mode unknown\n");
+ }
+ 
+ static ssize_t tiadc_set_mode(struct device *dev,
+-                struct device_attribute *attr, const char *buf, size_t count)
++		struct device_attribute *attr, const char *buf, size_t count)
+ {
+-        struct iio_dev *indio_dev = dev_get_drvdata(dev);
+-        struct tiadc_device *adc_dev = iio_priv(indio_dev);
+-        unsigned config;
++	struct iio_dev *indio_dev = dev_get_drvdata(dev);
++	struct tiadc_device *adc_dev = iio_priv(indio_dev);
++	unsigned config;
+ 
+-        config = tiadc_readl(adc_dev, REG_CTRL);
+-        config &= ~(CNTRLREG_TSCSSENB);
+-        tiadc_writel(adc_dev, REG_CTRL, config);
++	config = tiadc_readl(adc_dev, REG_CTRL);
++	config &= ~(CNTRLREG_TSCSSENB);
++	tiadc_writel(adc_dev, REG_CTRL, config);
+ 
+ 	if (!strncmp(buf, "oneshot", 7))
+-               adc_dev->is_continuous_mode = false;
+-        else if (!strncmp(buf, "continuous", 10))
+-                adc_dev->is_continuous_mode = true;
+-        else {
+-                dev_err(dev, "Operational mode unknown\n");
+-                return -EINVAL;
+-        }
+- 
++		adc_dev->is_continuous_mode = false;
++	else if (!strncmp(buf, "continuous", 10))
++		adc_dev->is_continuous_mode = true;
++	else {
++		dev_err(dev, "Operational mode unknown\n");
++		return -EINVAL;
++	}
++
+ 	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+-        config = tiadc_readl(adc_dev, REG_CTRL);
+-        tiadc_writel(adc_dev, REG_CTRL,
+-                        (config | CNTRLREG_TSCSSENB));
+-        return count;
++	config = tiadc_readl(adc_dev, REG_CTRL);
++	tiadc_writel(adc_dev, REG_CTRL,
++			(config | CNTRLREG_TSCSSENB));
++	return count;
+ }
+ 
+ static IIO_DEVICE_ATTR(mode, S_IRUGO | S_IWUSR, tiadc_show_mode,
+-                tiadc_set_mode, 0);
++		tiadc_set_mode, 0);
+ 
+ static struct attribute *tiadc_attributes[] = {
+-        &iio_dev_attr_mode.dev_attr.attr,
+-        NULL,
++	&iio_dev_attr_mode.dev_attr.attr,
++	NULL,
+ };
+ 
+ static const struct attribute_group tiadc_attribute_group = {
+-        .attrs = tiadc_attributes,
++	.attrs = tiadc_attributes,
+ };
+ 
+ static irqreturn_t tiadc_irq(int irq, void *private)
+ {
+-        struct iio_dev *idev = private;
+-        struct tiadc_device *adc_dev = iio_priv(idev);
++	struct iio_dev *idev = private;
++	struct tiadc_device *adc_dev = iio_priv(idev);
+ 	unsigned int status, config;
+ 
+-        status = tiadc_readl(adc_dev, REG_IRQSTATUS);
+-        if (status & IRQENB_FIFO1OVRRUN) {
+-                config = tiadc_readl(adc_dev, REG_CTRL);
+-                config &= ~(CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev, REG_CTRL, config);
+-
+-                tiadc_writel(adc_dev, REG_IRQSTATUS,
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW |
+-                                IRQENB_FIFO1THRES);
+- 
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                       (config | CNTRLREG_TSCSSENB));
++	status = tiadc_readl(adc_dev, REG_IRQSTATUS);
++	if (status & IRQENB_FIFO1OVRRUN) {
++		config = tiadc_readl(adc_dev, REG_CTRL);
++		config &= ~(CNTRLREG_TSCSSENB);
++		tiadc_writel(adc_dev, REG_CTRL, config);
++
++		tiadc_writel(adc_dev, REG_IRQSTATUS,
++				IRQENB_FIFO1OVRRUN |
++				IRQENB_FIFO1UNDRFLW |
++				IRQENB_FIFO1THRES);
++
++		tiadc_writel(adc_dev, REG_CTRL,
++		       (config | CNTRLREG_TSCSSENB));
++		return IRQ_HANDLED;
++	} else if (status & IRQENB_FIFO1THRES) {
++		tiadc_writel(adc_dev, REG_IRQCLR,
++				IRQENB_FIFO1THRES);
++
++		if (iio_buffer_enabled(idev)) {
++			if (!work_pending(&adc_dev->poll_work))
++				schedule_work(&adc_dev->poll_work);
++		} else {
++			wake_up_interruptible(&adc_dev->wq_data_avail);
++		}
++
+ 		return IRQ_HANDLED;
+-        } else if (status & IRQENB_FIFO1THRES) {
+-                tiadc_writel(adc_dev, REG_IRQCLR,
+-                                IRQENB_FIFO1THRES);
+-
+-                if (iio_buffer_enabled(idev)) {
+-                        if (!work_pending(&adc_dev->poll_work))
+-                                schedule_work(&adc_dev->poll_work);
+-                } else {
+-                        wake_up_interruptible(&adc_dev->wq_data_avail);
+-                }
+-
+-                return IRQ_HANDLED;      
+ 	} else {
+-                return IRQ_NONE;
+-        }
++		return IRQ_NONE;
++	}
+ }
+ 
+ static void tiadc_poll_handler(struct work_struct *work_s)
+ {
+-        struct tiadc_device *adc_dev =
+-                container_of(work_s, struct tiadc_device, poll_work);
+-        struct iio_dev *idev = iio_priv_to_dev(adc_dev);
+-        struct iio_buffer *buffer = idev->buffer;
+-        unsigned int fifo1count, readx1;
+-        int i;
+-        u32 *iBuf;
+-
+-        fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
+-        if (fifo1count * sizeof(u32) <
+-                                buffer->access->get_bytes_per_datum(buffer)) {
+-                dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
+-                                                                __func__);
+-                goto out;
+-        }
+-
+-        iBuf = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
+-        if (iBuf == NULL)
+-                goto out;
+-
+-        for (i = 0; i < fifo1count; i++) {
+-                readx1 = tiadc_readl(adc_dev, REG_FIFO1);
+-                readx1 &= FIFOREAD_DATA_MASK;
+-                iBuf[i] = readx1;
+-        }
+-
+-        buffer->access->store_to(buffer, (u8 *) iBuf);
+-	kfree(iBuf);
+-
+-out:	
++	struct tiadc_device *adc_dev =
++		container_of(work_s, struct tiadc_device, poll_work);
++	struct iio_dev *idev = iio_priv_to_dev(adc_dev);
++	struct iio_buffer *buffer = idev->buffer;
++	unsigned int fifo1count, readx1;
++	int i;
++	u32 *inputbuffer;
++
++	fifo1count = tiadc_readl(adc_dev, REG_FIFO1CNT);
++	if (fifo1count * sizeof(u32) <
++				buffer->access->get_bytes_per_datum(buffer)) {
++		dev_err(adc_dev->mfd_tscadc->dev, "%s: Short FIFO event\n",
++								__func__);
++		goto out;
++	}
++
++	inputbuffer = kmalloc((fifo1count) * sizeof(u32), GFP_KERNEL);
++	if (inputbuffer == NULL)
++		goto out;
++
++	for (i = 0; i < fifo1count; i++) {
++		readx1 = tiadc_readl(adc_dev, REG_FIFO1);
++		readx1 &= FIFOREAD_DATA_MASK;
++		inputbuffer[i] = readx1;
++	}
++
++	buffer->access->store_to(buffer, (u8 *) inputbuffer);
++	kfree(inputbuffer);
++
++out:
+ 	tiadc_writel(adc_dev, REG_IRQSTATUS,
+ 				IRQENB_FIFO1THRES);
+-        tiadc_writel(adc_dev, REG_IRQENABLE, 
++	tiadc_writel(adc_dev, REG_IRQENABLE,
+ 				IRQENB_FIFO1THRES);
+-    
++
+ }
+ 
+ static int tiadc_buffer_preenable(struct iio_dev *idev)
+ {
+-        struct iio_buffer *buffer = idev->buffer;
++	struct iio_buffer *buffer = idev->buffer;
+ 
+-        buffer->access->set_bytes_per_datum(buffer, 16);
+-        return 0;
++	buffer->access->set_bytes_per_datum(buffer, 16);
++	return 0;
+ }
+ 
+ static int tiadc_buffer_postenable(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
+-        struct iio_buffer *buffer = idev->buffer;
+-        unsigned int enb, config;
+-        int stepnum;
+-        u8 bit;
+-
+-        if (!adc_dev->is_continuous_mode) {
+-                printk("Data cannot be read continuously in one shot mode\n");
+-                return -EINVAL;
+-        } else {
+-
+-                config = tiadc_readl(adc_dev, REG_CTRL);
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                                        config & ~CNTRLREG_TSCSSENB);
+-                tiadc_writel(adc_dev, REG_CTRL,
+-                                        config |  CNTRLREG_TSCSSENB);
+-
+-                tiadc_writel(adc_dev,  REG_IRQSTATUS,
+-                                 IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN |
+-                                 IRQENB_FIFO1UNDRFLW);
+-                tiadc_writel(adc_dev,  REG_IRQENABLE,
+-                                 IRQENB_FIFO1THRES |
+-                                 IRQENB_FIFO1OVRRUN);
+-
+-                tiadc_writel(adc_dev, REG_SE, 0x00);
+-                for_each_set_bit(bit, buffer->scan_mask,
+-                                adc_dev->channels) {
+-                        struct iio_chan_spec const *chan = idev->channels + bit;
+-                        /*
+-                         * There are a total of 16 steps available
+-                         * that are shared between ADC and touchscreen.
+-                         * We start configuring from step 16 to 0 incase of
+-                         * ADC. Hence the relation between input channel
+-                         * and step for ADC would be as below.
+-                         */
+-                        stepnum = chan->channel + 9;
+-                        enb = tiadc_readl(adc_dev, REG_SE);
+-                        enb |= (1 << stepnum);
+-                        tiadc_writel(adc_dev, REG_SE, enb);
+-                }
+-                return 0;
+-        }
++	struct tiadc_device *adc_dev = iio_priv(idev);
++	struct iio_buffer *buffer = idev->buffer;
++	unsigned int enb, config;
++	int stepnum;
++	u8 bit;
++
++	if (!adc_dev->is_continuous_mode) {
++		pr_info("Data cannot be read continuously in one shot mode\n");
++		return -EINVAL;
++	} else {
++
++		config = tiadc_readl(adc_dev, REG_CTRL);
++		tiadc_writel(adc_dev, REG_CTRL,
++					config & ~CNTRLREG_TSCSSENB);
++		tiadc_writel(adc_dev, REG_CTRL,
++					config |  CNTRLREG_TSCSSENB);
++
++		tiadc_writel(adc_dev,  REG_IRQSTATUS,
++				 IRQENB_FIFO1THRES |
++				 IRQENB_FIFO1OVRRUN |
++				 IRQENB_FIFO1UNDRFLW);
++		tiadc_writel(adc_dev,  REG_IRQENABLE,
++				 IRQENB_FIFO1THRES |
++				 IRQENB_FIFO1OVRRUN);
++
++		tiadc_writel(adc_dev, REG_SE, 0x00);
++		for_each_set_bit(bit, buffer->scan_mask,
++				adc_dev->channels) {
++			struct iio_chan_spec const *chan = idev->channels + bit;
++			/*
++			 * There are a total of 16 steps available
++			 * that are shared between ADC and touchscreen.
++			 * We start configuring from step 16 to 0 incase of
++			 * ADC. Hence the relation between input channel
++			 * and step for ADC would be as below.
++			 */
++			stepnum = chan->channel + 9;
++			enb = tiadc_readl(adc_dev, REG_SE);
++			enb |= (1 << stepnum);
++			tiadc_writel(adc_dev, REG_SE, enb);
++		}
++		return 0;
++	}
+ }
+ 
+ static int tiadc_buffer_postdisable(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
+-  
++	struct tiadc_device *adc_dev = iio_priv(idev);
++
+ 	tiadc_writel(adc_dev, REG_IRQCLR, (IRQENB_FIFO1THRES |
+-                                IRQENB_FIFO1OVRRUN |
+-                                IRQENB_FIFO1UNDRFLW));
+-        tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
+-        return 0;
++				IRQENB_FIFO1OVRRUN |
++				IRQENB_FIFO1UNDRFLW));
++	tiadc_writel(adc_dev, REG_SE, STPENB_STEPENB_TC);
++	return 0;
+ }
+ 
+ static const struct iio_buffer_setup_ops tiadc_buffer_setup_ops = {
+-        .preenable = &tiadc_buffer_preenable,
+-        .postenable = &tiadc_buffer_postenable,
+-        .postdisable = &tiadc_buffer_postdisable,
++	.preenable = &tiadc_buffer_preenable,
++	.postenable = &tiadc_buffer_postenable,
++	.postdisable = &tiadc_buffer_postdisable,
+ };
+ 
+ static int tiadc_config_sw_ring(struct iio_dev *idev)
+ {
+-        struct tiadc_device *adc_dev = iio_priv(idev);
++	struct tiadc_device *adc_dev = iio_priv(idev);
+ 
+-        idev->buffer = iio_kfifo_allocate(idev);
+-        if (!idev->buffer)
+-                return(-ENOMEM);
++	idev->buffer = iio_kfifo_allocate(idev);
++	if (!idev->buffer)
++		return -ENOMEM;
+ 
+-        idev->setup_ops = &tiadc_buffer_setup_ops;
++	idev->setup_ops = &tiadc_buffer_setup_ops;
+ 
+-        INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
++	INIT_WORK(&adc_dev->poll_work, &tiadc_poll_handler);
+ 
+-        idev->modes |= INDIO_BUFFER_HARDWARE;
+-        return 0;
++	idev->modes |= INDIO_BUFFER_HARDWARE;
++	return 0;
+ }
+ 
+ static const char * const chan_name_ain[] = {
+@@ -389,14 +389,14 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 	unsigned long timeout = jiffies + usecs_to_jiffies
+ 				(IDLE_TIMEOUT * adc_dev->channels);
+ 
+-       if (adc_dev->is_continuous_mode) {
+-               printk("One shot mode not enabled\n");
+-               return -EINVAL;
+-       } else {
++	if (adc_dev->is_continuous_mode) {
++		pr_info("One shot mode not enabled\n");
++		return -EINVAL;
++	} else {
+ 
+ 		step_en = get_adc_step_mask(adc_dev);
+ 		am335x_tsc_se_set(adc_dev->mfd_tscadc, step_en);
+-	 
++
+ 		/* Wait for ADC sequencer to complete sampling */
+ 		while (tiadc_readl(adc_dev, REG_ADCFSM) & SEQ_STATUS) {
+ 			if (time_after(jiffies, timeout))
+@@ -437,16 +437,17 @@ static int tiadc_read_raw(struct iio_dev *indio_dev,
+ 			}
+ 		}
+ 
+-		switch (mask){
+-			case IIO_CHAN_INFO_RAW : /*Do nothing. Above code works fine.*/
++		switch (mask) {
++		case IIO_CHAN_INFO_RAW: /*Do nothing. Above code works fine.*/
+ 						break;
+-			case IIO_CHAN_INFO_SCALE : {
+-				/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
+-				AVDD should come from DT.*/
+-				*val = div_u64( (u64)(*val) * 1800 , 4096);
++		case IIO_CHAN_INFO_SCALE: {
++			/*12 Bit adc. Scale value for 1800mV AVDD. Ideally
++			AVDD should come from DT.*/
++				*val = div_u64((u64)(*val) * 1800 , 4096);
+ 				break;
+ 			}
+-			default: break;
++		default:
++			break;
+ 		}
+ 
+ 		if (found == false)
+@@ -518,7 +519,7 @@ static int tiadc_probe(struct platform_device *pdev)
+ 	err = tiadc_config_sw_ring(indio_dev);
+ 	if (err < 0)
+ 		goto err_unregister;
+- 
++
+ 	err = iio_buffer_register(indio_dev,
+ 		indio_dev->channels, indio_dev->num_channels);
+ 	if (err < 0)
+@@ -588,16 +589,16 @@ static int tiadc_resume(struct device *dev)
+ 	struct tiadc_device *adc_dev = iio_priv(indio_dev);
+ 	unsigned int restore;
+ 
+-        restore = tiadc_readl(adc_dev, REG_CTRL);
+-        restore &= ~(CNTRLREG_TSCSSENB);
+-        tiadc_writel(adc_dev, REG_CTRL, restore);
++	restore = tiadc_readl(adc_dev, REG_CTRL);
++	restore &= ~(CNTRLREG_TSCSSENB);
++	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+-    tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
+-    tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
++	tiadc_writel(adc_dev, REG_FIFO1THR, FIFO1_THRESHOLD);
++	tiadc_step_config(adc_dev, adc_dev->is_continuous_mode);
+ 
+ 	/* Make sure ADC is powered up */
+ 	restore &= ~(CNTRLREG_POWERDOWN);
+-        restore |= CNTRLREG_TSCSSENB;
++	restore |= CNTRLREG_TSCSSENB;
+ 	tiadc_writel(adc_dev, REG_CTRL, restore);
+ 
+ 	return 0;
+-- 
+1.7.9.5
+

--- a/patches/adc/0021-input-ti_am335x_tsc.c-fix-checkpatch.pl-issues.patch
+++ b/patches/adc/0021-input-ti_am335x_tsc.c-fix-checkpatch.pl-issues.patch
@@ -1,0 +1,59 @@
+From 08c6e9713f471f54088ff10b7ce50e78dfc5b134 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sun, 14 Jul 2013 12:05:15 +0100
+Subject: [PATCH 21/22] input: ti_am335x_tsc.c fix checkpatch.pl issues
+
+code formatting fixes
+---
+ drivers/input/touchscreen/ti_am335x_tsc.c |   28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/input/touchscreen/ti_am335x_tsc.c b/drivers/input/touchscreen/ti_am335x_tsc.c
+index 4bf2ee6..ba7abfe 100644
+--- a/drivers/input/touchscreen/ti_am335x_tsc.c
++++ b/drivers/input/touchscreen/ti_am335x_tsc.c
+@@ -260,19 +260,19 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	unsigned int fsm;
+ 
+ 	status = titsc_readl(ts_dev, REG_IRQSTATUS);
+- 
+-        /*
+-         * ADC and touchscreen share the IRQ line.
+-         * FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
+-         * interrupts are used by ADC,
+-         * hence return from touchscreen IRQ handler if FIFO1
+-         * related interrupts occurred.
+-         */
+-       if ((status & IRQENB_FIFO1THRES) ||
+-                       (status & IRQENB_FIFO1OVRRUN) ||
+-                       (status & IRQENB_FIFO1UNDRFLW))
+-                return IRQ_NONE;
+-        else if (status & IRQENB_FIFO0THRES) {
++
++	/*
++	* ADC and touchscreen share the IRQ line.
++	* FIFO1 threshold, FIFO1 Overrun and FIFO1 underflow
++	* interrupts are used by ADC,
++	* hence return from touchscreen IRQ handler if FIFO1
++	* related interrupts occurred.
++	*/
++	if ((status & IRQENB_FIFO1THRES) ||
++			(status & IRQENB_FIFO1OVRRUN) ||
++			(status & IRQENB_FIFO1UNDRFLW))
++		return IRQ_NONE;
++	else if (status & IRQENB_FIFO0THRES) {
+ 		titsc_read_coordinates(ts_dev, &x, &y, &z1, &z2);
+ 
+ 		if (ts_dev->pen_down && z1 != 0 && z2 != 0) {
+@@ -326,7 +326,7 @@ static irqreturn_t titsc_irq(int irq, void *dev)
+ 	}
+ 
+ 	if (irqclr) {
+-		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr) );
++		titsc_writel(ts_dev, REG_IRQSTATUS, (status | irqclr));
+ 		am335x_tsc_se_update(ts_dev->mfd_tscadc);
+ 		return IRQ_HANDLED;
+ 	}
+-- 
+1.7.9.5
+

--- a/patches/adc/0022-mfd-ti_am335x_tscadc.c-fix-checkpatch.pl-issues.patch
+++ b/patches/adc/0022-mfd-ti_am335x_tscadc.c-fix-checkpatch.pl-issues.patch
@@ -1,0 +1,37 @@
+From 4cdd9b71995fab0caaaec3000f0eb19faf606780 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah <zubair.lutfullah@gmail.com>
+Date: Sun, 14 Jul 2013 12:06:52 +0100
+Subject: [PATCH 22/22] mfd: ti_am335x_tscadc.c fix checkpatch.pl issues
+
+code formatting corrected.
+---
+ drivers/mfd/ti_am335x_tscadc.c |    6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mfd/ti_am335x_tscadc.c b/drivers/mfd/ti_am335x_tscadc.c
+index e7314e4..b8d7dfb 100644
+--- a/drivers/mfd/ti_am335x_tscadc.c
++++ b/drivers/mfd/ti_am335x_tscadc.c
+@@ -278,8 +278,8 @@ static int tscadc_suspend(struct device *dev)
+ 	struct ti_tscadc_dev	*tscadc_dev = dev_get_drvdata(dev);
+ 
+ 	tscadc_writel(tscadc_dev, REG_SE, 0x00);
+-        tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
+-        tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
++	tscadc_dev->irqstat = tscadc_readl(tscadc_dev, REG_IRQENABLE);
++	tscadc_dev->ctrl = tscadc_readl(tscadc_dev, REG_CTRL);
+ 	pm_runtime_put_sync(dev);
+ 
+ 	return 0;
+@@ -297,7 +297,7 @@ static int tscadc_resume(struct device *dev)
+ 	if (tscadc_dev->tsc_cell != -1)
+ 		tscadc_idle_config(tscadc_dev);
+ 	am335x_tsc_se_update(tscadc_dev);
+-        tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
++	tscadc_writel(tscadc_dev, REG_CTRL, tscadc_dev->ctrl);
+ 
+ 	return 0;
+ }
+-- 
+1.7.9.5
+


### PR DESCRIPTION
This commit adds only the new files for continuous sampling support on a clean clone of 3.11
Is there any reason patch.sh of 3.11 doesn't have adc in the set to compile?

original commit message

This adds a bunch of patches to the adc patchset enabling continous
sampling mode. A large buffer of data can now be read via /dev/iio entries

The work is forward ported from the Arago tree.
The original author is Rachil Patna.

Some of his patches might seem missing from Arago but that is because

1) I incorporated some of his minor bugfixes in the same large main patch.
2) Some of the patches have already been incorporated in the patchset in mfd-next.

The rest of the small bug fixes by Russ Dill are kept in separate patches.

All in all. This brings all the functionality of the ADC driver in the Arago tree
to the BBB.

evtest for touchscreen does register events too
