### PR TITLE
readme: add CROSS_COMPILE and ARCH flags into kernel make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To build it:
 ```
 cd kernel
 cp ../configs/beaglebone .config
-make uImage dtbs
+make ARCH=arm CROSS_COMPILE=arm-xxxx-linux-gnueabi- uImage dtbs
 ```
 
 copy over uImage and am335x-bone.dtb to /boot


### PR DESCRIPTION
It can be a bit confusing to a new user when they first try to compile the kernel as per these instructions, as it will use the host environment to compile the kernel, which will fail. Add in example CROSS_COMPILE value, and add ARCH=arm to at least send them down the right path.
