### PR TITLE
fix thinko in 0008-OF-Introduce-DT-overlay-support.patch

### DIFF
--- a/patches/of-fixes/0008-OF-Introduce-DT-overlay-support.patch
+++ b/patches/of-fixes/0008-OF-Introduce-DT-overlay-support.patch
@@ -1235,7 +1235,7 @@ index 6ed844d..7b3e332 100644
 +	return -ENOTSUPP;
 +}
 +
-+int of_free_overlay_info(int cnt, struct of_overlay_info *ovinfo)
++static inline int of_free_overlay_info(int cnt, struct of_overlay_info *ovinfo)
 +{
 +	return -ENOTSUPP;
 +}


### PR DESCRIPTION
Putting a non-inline function in a header is bad juju. ;-)
