### PR TITLE
ASoC: davinci: McASP: Make code generic remove hardcode

### DIFF
--- a/patches/hdmi/0028-Make-the-McASP-code-generic-again-remove-all-hardcod.patch
+++ b/patches/hdmi/0028-Make-the-McASP-code-generic-again-remove-all-hardcod.patch
@@ -1,0 +1,170 @@
+From b45ed989afdc02df1a7d9ea9809eccf9cba2be50 Mon Sep 17 00:00:00 2001
+From: Darren Etheridge <detheridge@ti.com>
+Date: Mon, 1 Jul 2013 16:06:55 -0500
+Subject: [PATCH 28/28] Make the McASP code generic again, remove all
+ hardcoding
+
+After adding the HDMI audio, the McASP driver was left in
+a mess, and broken when used with other capes.  This patch
+puts things right, and moves the necessary config code into
+davinci-evm.c where it belongs.
+
+Signed-off-by: Darren Etheridge <detheridge@ti.com>
+---
+ sound/soc/davinci/davinci-evm.c   |   48 +++++++++++++++++++++++++++----------
+ sound/soc/davinci/davinci-mcasp.c |   12 ++++------
+ 2 files changed, 40 insertions(+), 20 deletions(-)
+
+diff --git a/sound/soc/davinci/davinci-evm.c b/sound/soc/davinci/davinci-evm.c
+index 7a7fc47..421feb0 100644
+--- a/sound/soc/davinci/davinci-evm.c
++++ b/sound/soc/davinci/davinci-evm.c
+@@ -146,6 +146,32 @@ static const struct snd_soc_dapm_route audio_map[] = {
+ };
+ 
+ /* Logic for a aic3x as connected on a davinci-evm */
++static int evm_tda998x_init(struct snd_soc_pcm_runtime *rtd)
++{
++	struct snd_soc_dai *codec_dai = rtd->codec_dai;
++	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
++	int ret;
++
++	ret = snd_soc_dai_set_clkdiv(cpu_dai, 0, 1);
++	if (ret < 0)
++		return ret;
++
++	ret = snd_soc_dai_set_clkdiv(cpu_dai, 1, 8);
++	if (ret < 0)
++		return ret;
++
++	ret = snd_soc_dai_set_sysclk(cpu_dai, 0, 0, SND_SOC_CLOCK_IN);
++	if (ret < 0)
++		return ret;
++
++	ret = snd_soc_dai_set_fmt(cpu_dai, SND_SOC_DAIFMT_CBS_CFS | SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_IB_NF);
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++/* Logic for a aic3x as connected on a davinci-evm */
+ static int evm_aic3x_init(struct snd_soc_pcm_runtime *rtd)
+ {
+ 	struct snd_soc_codec *codec = rtd->codec;
+@@ -380,11 +406,12 @@ static int davinci_evm_probe(struct platform_device *pdev)
+ 		evm_dai.name		= "NXP TDA HDMI Chip";
+ 		evm_dai.stream_name	= "HDMI";
+ 		evm_dai.codec_dai_name	= "nxp-hdmi-hifi";
++		evm_dai.init = evm_tda998x_init;
+ 
+-		/* 
+-		 * Move GPIO handling out of the probe, if probe gets 
++		/*
++		 * Move GPIO handling out of the probe, if probe gets
+ 		 * deferred, the gpio will have been claimed on previous
+-		 * probe and will fail on the second and susequent probes 
++		 * probe and will fail on the second and susequent probes
+ 		 */
+ 		clk_gpio = of_get_named_gpio(np, "mcasp_clock_enable", 0);
+ 		if (clk_gpio < 0) {
+@@ -398,11 +425,8 @@ static int davinci_evm_probe(struct platform_device *pdev)
+ 		  return -EINVAL;
+ 		}
+ 		gpio_set_value(clk_gpio, 1);
+-		evm_dai.dai_fmt = SND_SOC_DAIFMT_CBS_CFS | SND_SOC_DAIFMT_DSP_B | SND_SOC_DAIFMT_IB_NF;
+ 		break;
+-	  
+ 	}
+-	
+ 
+ 	evm_dai.codec_of_node = of_parse_phandle(np, "ti,audio-codec", 0);
+ 	if (!evm_dai.codec_of_node)
+@@ -421,9 +445,9 @@ static int davinci_evm_probe(struct platform_device *pdev)
+ 		return ret;
+ 
+ 	ret = snd_soc_register_card(&evm_soc_card);
+-	if (ret) {
++	if (ret)
+ 		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n", ret);
+-	} 
++
+ 	return ret;
+ }
+ 
+@@ -460,9 +484,8 @@ static int __init evm_init(void)
+ 	 * If dtb is there, the devices will be created dynamically.
+ 	 * Only register platfrom driver structure.
+ 	 */
+-	if (of_have_populated_dt()) {
+-	  return platform_driver_register(&davinci_evm_driver);
+-	}
++	if (of_have_populated_dt())
++		return platform_driver_register(&davinci_evm_driver);
+ #endif
+ 
+ 	if (machine_is_davinci_evm()) {
+@@ -483,9 +506,8 @@ static int __init evm_init(void)
+ 	} else if (machine_is_davinci_da850_evm()) {
+ 		evm_snd_dev_data = &da850_snd_soc_card;
+ 		index = 0;
+-	} else {
++	} else
+ 		return -EINVAL;
+-	}
+ 
+ 	evm_snd_device = platform_device_alloc("soc-audio", index);
+ 	if (!evm_snd_device)
+diff --git a/sound/soc/davinci/davinci-mcasp.c b/sound/soc/davinci/davinci-mcasp.c
+index bef4e72..83232c6 100644
+--- a/sound/soc/davinci/davinci-mcasp.c
++++ b/sound/soc/davinci/davinci-mcasp.c
+@@ -484,6 +484,10 @@ static int davinci_mcasp_set_dai_fmt(struct snd_soc_dai *cpu_dai,
+ 		mcasp_clr_bits(dev->base + DAVINCI_MCASP_TXFMCTL_REG, FSXDUR);
+ 		mcasp_clr_bits(dev->base + DAVINCI_MCASP_RXFMCTL_REG, FSRDUR);
+ 		break;
++	case SND_SOC_DAIFMT_I2S:
++		mcasp_set_bits(dev->base + DAVINCI_MCASP_TXFMCTL_REG, FSXDUR);
++		mcasp_set_bits(dev->base + DAVINCI_MCASP_RXFMCTL_REG, FSRDUR);
++		break;
+ 	default:
+ 		/* configure a full-word SYNC pulse (LRCLK) */
+ 		mcasp_set_bits(dev->base + DAVINCI_MCASP_TXFMCTL_REG, FSXDUR);
+@@ -498,16 +502,13 @@ static int davinci_mcasp_set_dai_fmt(struct snd_soc_dai *cpu_dai,
+ 	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
+ 	case SND_SOC_DAIFMT_CBS_CFS:
+ 		/* codec is clock and frame slave */
+-	  	mcasp_set_bits(base + DAVINCI_MCASP_ACLKXCTL_REG, ACLKXE | ACLKXDIV(7));
+-	  	mcasp_set_bits(base + DAVINCI_MCASP_AHCLKXCTL_REG,  AHCLKXDIV(0));
+-	  	mcasp_clr_bits(base + DAVINCI_MCASP_AHCLKXCTL_REG,  AHCLKXE);
++		mcasp_set_bits(base + DAVINCI_MCASP_ACLKXCTL_REG, ACLKXE);
+ 		mcasp_set_bits(base + DAVINCI_MCASP_TXFMCTL_REG, AFSXE);
+ 
+ 		mcasp_set_bits(base + DAVINCI_MCASP_ACLKRCTL_REG, ACLKRE);
+ 		mcasp_set_bits(base + DAVINCI_MCASP_RXFMCTL_REG, AFSRE);
+ 
+ 		mcasp_set_bits(base + DAVINCI_MCASP_PDIR_REG, ACLKX | AFSX);
+-		mcasp_clr_bits(base + DAVINCI_MCASP_PDIR_REG, AHCLKX);
+ 		break;
+ 	case SND_SOC_DAIFMT_CBM_CFS:
+ 		/* codec is clock master and frame slave */
+@@ -749,7 +750,6 @@ static void davinci_hw_param(struct davinci_audio_dev *dev, int stream)
+ 	if (stream == SNDRV_PCM_STREAM_PLAYBACK) {
+ 		/* bit stream is MSB first  with no delay */
+ 		/* DSP_B mode */
+-	  	mcasp_clr_bits(dev->base + DAVINCI_MCASP_AHCLKXCTL_REG, AHCLKXE);
+ 		mcasp_set_reg(dev->base + DAVINCI_MCASP_TXTDM_REG, mask);
+ 		mcasp_set_bits(dev->base + DAVINCI_MCASP_TXFMT_REG, TXORD);
+ 
+@@ -759,8 +759,6 @@ static void davinci_hw_param(struct davinci_audio_dev *dev, int stream)
+ 		else
+ 			printk(KERN_ERR "playback tdm slot %d not supported\n",
+ 				dev->tdm_slots);
+-		mcasp_set_bits(dev->base + DAVINCI_MCASP_TXFMCTL_REG, AFSXE);
+-		mcasp_set_bits(dev->base + DAVINCI_MCASP_TXFMCTL_REG, FSXDUR);
+ 	} else {
+ 		/* bit stream is MSB first with no delay */
+ 		/* DSP_B mode */
+-- 
+1.7.9.5
+


### PR DESCRIPTION
This code clean up the davinci-evm and davindi-mcasp driver.  It also fixes the audio quality issue when using the audio cape.
