### PR TITLE
Fix USB Babble Causes DBus Shutdown

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -24,7 +24,7 @@ EXTERNAL_TREE="git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable
 EXTERNAL_BRANCH="linux-3.12.y"
 EXTERNAL_SHA="4a5804b8c293b23786b0743fc9c64b64f5099048"
 
-PATCHSET="omap-next-dt dma-devel general-fixes dtc-fixes dtc-overlays of-fixes pdev-fixes mmc-fixes dts-fixes i2c-fixes pinctrl-fixes capemgr reset capes lcdc-fixes net deassert-hard-reset cape-import audio drm cpufreq pru"
+PATCHSET="omap-next-dt dma-devel general-fixes dtc-fixes dtc-overlays of-fixes pdev-fixes mmc-fixes dts-fixes i2c-fixes pinctrl-fixes capemgr reset capes lcdc-fixes net deassert-hard-reset cape-import audio drm cpufreq pru usb"
 
 git_kernel_stable () {
 	git pull git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git master --tags || true

--- a/patches/usb/0001-usb-musb-core-Fix-remote-wakeup-resume.patch
+++ b/patches/usb/0001-usb-musb-core-Fix-remote-wakeup-resume.patch
@@ -1,0 +1,50 @@
+From d1054071bf913dac6d0cb8c58d87a66d9fcd8210 Mon Sep 17 00:00:00 2001
+From: Roger Quadros <rogerq@ti.com>
+Date: Tue, 4 Feb 2014 15:29:33 +0200
+Subject: [PATCH] usb: musb: core: Fix remote-wakeup resume
+
+During resume don't touch SUSPENDM/RESUME bits of POWER register
+while restoring controller context. These bits might be changed
+by the controller during resume operation and so will be different
+than what they were during suspend.
+
+e.g. SUSPENDM bit is set by software during USB global suspend but
+automatically cleared by the controller during remote wakeup or
+during resume. Setting this bit back while restoring context
+causes undesired behaviour. i.e. Babble interrupt is generated
+and USB is broken.
+
+Signed-off-by: Roger Quadros <rogerq@ti.com>
+Signed-off-by: Felipe Balbi <balbi@ti.com>
+---
+ drivers/usb/musb/musb_core.c |   10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/usb/musb/musb_core.c b/drivers/usb/musb/musb_core.c
+index f7dca0b..6b6c35b 100644
+--- a/drivers/usb/musb/musb_core.c
++++ b/drivers/usb/musb/musb_core.c
+@@ -2122,11 +2122,19 @@ static void musb_restore_context(struct musb *musb)
+ 	void __iomem *musb_base = musb->mregs;
+ 	void __iomem *ep_target_regs;
+ 	void __iomem *epio;
++	u8 power;
+ 
+ 	musb_writew(musb_base, MUSB_FRAME, musb->context.frame);
+ 	musb_writeb(musb_base, MUSB_TESTMODE, musb->context.testmode);
+ 	musb_write_ulpi_buscontrol(musb->mregs, musb->context.busctl);
+-	musb_writeb(musb_base, MUSB_POWER, musb->context.power);
++
++	/* Don't affect SUSPENDM/RESUME bits in POWER reg */
++	power = musb_readb(musb_base, MUSB_POWER);
++	power &= MUSB_POWER_SUSPENDM | MUSB_POWER_RESUME;
++	musb->context.power &= ~(MUSB_POWER_SUSPENDM | MUSB_POWER_RESUME);
++	power |= musb->context.power;
++	musb_writeb(musb_base, MUSB_POWER, power);
++
+ 	musb_writew(musb_base, MUSB_INTRTXE, musb->intrtxe);
+ 	musb_writew(musb_base, MUSB_INTRRXE, musb->intrrxe);
+ 	musb_writeb(musb_base, MUSB_INTRUSBE, musb->context.intrusbe);
+-- 
+1.7.9.5
+


### PR DESCRIPTION
I have noticed while using some USB hubs, a USB babble when enumerating a connected device causes the power to the hub to be shutdown and USB read errors to show up in the logs.  This shows up during boot as well as after boot when certain USB devices are connected to the hub.  Has anyone else heard of a problem similar to this.  It could be the fix we need for USB Hot-Plug.  I have tested it on 3.12 as well as 3.13 and USB works fine.  On 3.8 this patch fixes enumeration on boot, but if certain devices are connected to the hub after boot then logs show "bogus host resume" followed by "read errors" then eventually the kernel locks up (still debugging this).
