### PR TITLE
Use https:// instead of git://, preventing MitM

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -20,7 +20,7 @@ RECIPEFILE="${DIR}/recipes/${RECIPENAME}"
 TAG="v3.14.1"
 EXTRATAG=""
 
-EXTERNAL_TREE="git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git"
+EXTERNAL_TREE="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git"
 #EXTERNAL_BRANCH="master"
 EXTERNAL_BRANCH="linux-3.14.y"
 EXTERNAL_SHA="387df1bd3fc46bc695b317dda38b3254f4409036"
@@ -28,11 +28,11 @@ EXTERNAL_SHA="387df1bd3fc46bc695b317dda38b3254f4409036"
 PATCHSET="dts fixes usb dts-bone dts-bone-capes static-capes"
 
 git_kernel_stable () {
-	git pull git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git master --tags || true
+	git pull https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git master --tags || true
 }
 
 git_pull_torvalds () {
-	git pull git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git master --tags || true
+	git pull https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git master --tags || true
 	#Maybe, we need a stable tag '3.0.2'?
 	git tag | grep ${TAG} >/dev/null || git_kernel_stable
 }
@@ -44,7 +44,7 @@ fi
 cd ${DIR}/kernel
 
 if [ ! -f ./.git/config ] ; then
-	git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git .
+	git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git .
 else
 	git fetch
 fi


### PR DESCRIPTION
(Also applies to the older branches)
