### PR TITLE
cape: add BB-BONE-SERL-01-00A2

### DIFF
--- a/patches/capes/0038-cape-add-BB-BONE-SERL-01-00A2.patch
+++ b/patches/capes/0038-cape-add-BB-BONE-SERL-01-00A2.patch
@@ -1,0 +1,65 @@
+From f2f41d0c8ab6ad0a93b7b90a5130f1349175250d Mon Sep 17 00:00:00 2001
+From: Tyler Baker <tyler.baker@linaro.org>
+Date: Thu, 24 Jul 2014 14:04:12 -0700
+Subject: [PATCH] cape: add BB-BONE-SERL-01-00A2
+
+Signed-off-by: Tyler Baker <tyler.baker@linaro.org>
+---
+ firmware/capes/BB-BONE-SERL-01-00A2.dts |   45 +++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+ create mode 100644 firmware/capes/BB-BONE-SERL-01-00A2.dts
+
+diff --git a/firmware/capes/BB-BONE-SERL-01-00A2.dts b/firmware/capes/BB-BONE-SERL-01-00A2.dts
+new file mode 100644
+index 0000000..3e10116
+--- /dev/null
++++ b/firmware/capes/BB-BONE-SERL-01-00A2.dts
+@@ -0,0 +1,45 @@
++/*
++* Copyright (C) 2013 Martin Gysel <me@bearsh.org>
++*
++* This program is free software; you can redistribute it and/or modify
++* it under the terms of the GNU General Public License version 2 as
++* published by the Free Software Foundation.
++*/
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "ti,beaglebone", "ti,beaglebone-black";
++	part-number = "BB-BONE-SERL-01";
++	version = "00A2";
++
++	/* state the resources this cape uses */
++	exclusive-use =
++		/* the pin header uses */
++		"P9.26",		/* dcan1: dcan1_tx */
++		"P9.24",		/* dcan1: dcan1_rx */
++		/* the hardware IP uses */
++		"dcan1";
++
++	fragment@0 {
++		target = <&am33xx_pinmux>;
++		__overlay__ {
++			bone_serl_01_dcan1_pins: bone_serl_01_dcan1_pins {
++				pinctrl-single,pins = <
++					0x180 0x02      /* uart1_rxd.d_can1_tx", OUTPUT | MODE2 */
++					0x184 0x32      /* uart1_txd.d_can1_rx", INPUT_PULLUP | MODE2 */
++				>;
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&dcan1>;
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&bone_serl_01_dcan1_pins>;
++		};
++	};
++};
+-- 
+1.7.9.5
+


### PR DESCRIPTION
This patch adds a dts fragment for the A2 revision of the CANbus Cape. Tested on BBB 3.8, 3.12.
